### PR TITLE
Added support for connecting to a Unix domain socket.

### DIFF
--- a/lib/async_conduit.ml
+++ b/lib/async_conduit.ml
@@ -46,6 +46,11 @@ ELSE
     | `TCP -> return (rd,wr)
 END
 
+  let connect_unix ?interrupt ~path () =
+    Tcp.connect ?interrupt (Tcp.to_file path)
+    >>= fun (_, rd, wr) ->
+    return (rd,wr)
+
 end
 
 module Server = struct

--- a/lib/async_conduit.mli
+++ b/lib/async_conduit.mli
@@ -34,6 +34,10 @@ module Client : sig
     mode:t ->
     host:string -> port:int -> unit -> (ic * oc) io
 
+  val connect_unix :
+    ?interrupt:unit io ->
+    path:string -> unit -> (ic * oc) io
+
 end
 
 module Server : sig


### PR DESCRIPTION
This PR adds a connect_unix function to support Unix domain sockets.

I'm using it build Docker bindings, which runs over a Unix socket by default:

https://github.com/arjunguha/ocaml-docker

If I can get this merged in some form, I'd want to open a PR for cohttp next:

https://github.com/arjunguha/ocaml-cohttp/commit/d918afa7c682a6c4a13d4030fe07aa2b216c3230
