### PR TITLE
Refine `Vchan type, functorise mirage over Vchan

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@
 TAGS=principal,annot,bin_annot,short_paths,thread,strict_sequence
 J_FLAG=2
 
-BASE_PKG="sexplib ipaddr cstruct uri stringext"
+BASE_PKG="sexplib ipaddr cstruct uri stringext vchan"
 SYNTAX_PKG="camlp4.macro sexplib.syntax"
 
 # The Async backend is only supported in OCaml 4.01.0+

--- a/lib/Conduit_lwt_unix.mli
+++ b/lib/Conduit_lwt_unix.mli
@@ -19,6 +19,7 @@ type client = [
   | `OpenSSL of string * Ipaddr.t * int
   | `TCP of Ipaddr.t * int
   | `Unix_domain_socket of string
+  | `Vchan of int * Vchan.Port.t
 ] with sexp
 
 type server = [
@@ -29,6 +30,7 @@ type server = [
       [ `Port of int ]
   | `TCP of [ `Port of int ]
   | `Unix_domain_socket of [ `File of string ]
+  | `Vchan of int * Vchan.Port.t
 ] with sexp
 
 type 'a io = 'a Lwt.t

--- a/lib/conduit.ml
+++ b/lib/conduit.ml
@@ -22,7 +22,7 @@ open Sexplib.Std
 type endp = [
   | `TCP of Ipaddr.t * int        (** ipaddr and dst port *)
   | `Unix_domain_socket of string (** unix file path *)
-  | `Vchan of string list         (** xenstore path *)
+  | `Vchan of int * Vchan.Port.t  (** domain id, port *)
   | `TLS of string * endp         (** wrap in a TLS channel, [hostname,endp] *)
   | `Unknown of string            (** failed resolution *)
 ] with sexp

--- a/lib/conduit.mli
+++ b/lib/conduit.mli
@@ -21,7 +21,7 @@
 type endp = [
   | `TCP of Ipaddr.t * int        (** IP address and destination port *)
   | `Unix_domain_socket of string (** Unix domain file path *)
-  | `Vchan of string list         (** Xenstore path *)
+  | `Vchan of int * Vchan.Port.t  (** domain id, port *)
   | `TLS of string * endp         (** Wrap in a TLS channel, [hostname,endp] *)
   | `Unknown of string            (** Failed resolution *)
 ] with sexp

--- a/lib/conduit_mirage.mli
+++ b/lib/conduit_mirage.mli
@@ -17,15 +17,15 @@
 
 type client = [
   | `TCP of Ipaddr.t * int
-  | `Vchan of string list
+  | `Vchan of int * Vchan.Port.t
 ] with sexp
 
 type server = [
   | `TCP of [ `Port of int ]
-  | `Vchan of string list
+  | `Vchan of int * Vchan.Port.t
 ] with sexp
 
-module Make_flow(S:V1_LWT.STACKV4) : V1_LWT.FLOW
+module Make_flow(S:V1_LWT.STACKV4)(V: Vchan.S.ENDPOINT) : V1_LWT.FLOW
 
 module type S = sig
 
@@ -51,4 +51,4 @@ module type S = sig
   val endp_to_server: ctx:ctx -> Conduit.endp -> server io
 end
 
-module Make(S:V1_LWT.STACKV4) : S with type stack = S.t
+module Make(S:V1_LWT.STACKV4)(V: Vchan.S.ENDPOINT) : S with type stack = S.t

--- a/lib/conduit_resolver.ml
+++ b/lib/conduit_resolver.ml
@@ -22,7 +22,7 @@ open Sexplib.Std
 type endp = [
   | `TCP of Ipaddr.t * int        (** ipaddr and dst port *)
   | `Unix_domain_socket of string (** unix file path *)
-  | `Vchan of string list         (** xenstore path *)
+  | `Vchan of int * Vchan.Port.t  (** domain id, port *)
   | `TLS of string * endp         (** wrap in a TLS channel *)
   | `Unknown of string            (** failed resolution *)
 ] with sexp


### PR DESCRIPTION
We change the `Vchan to int (\* domid _) \* Vchan.Port.t (_ port *)
This matches the upstream convention. Note we also add a dependency
on vchan.

Signed-off-by: David Scott dave.scott@citrix.com

(I thought I'd publish the work in progress before going too much further)
