### PR TITLE
Add accessor to compute sockaddr information of flow

### DIFF
--- a/lib/Conduit_lwt_unix.ml
+++ b/lib/Conduit_lwt_unix.ml
@@ -31,7 +31,7 @@ type client = [
 
 type server = [
   | `OpenSSL of
-      [ `Crt_file_path of string ] * 
+      [ `Crt_file_path of string ] *
       [ `Key_file_path of string ] *
       [ `Password of bool -> string | `No_password ] *
       [ `Port of int ]
@@ -42,7 +42,7 @@ type server = [
 type tls_server_key = [
   | `None
   | `OpenSSL of
-      [ `Crt_file_path of string ] * 
+      [ `Crt_file_path of string ] *
       [ `Key_file_path of string ] *
       [ `Password of bool -> string | `No_password ]
 ]
@@ -50,7 +50,7 @@ type tls_server_key = [
 type ctx = {
   src: Unix.sockaddr option;
   tls_server_key: tls_server_key;
-} 
+}
 
 type tcp_flow = {
   fd: Lwt_unix.file_descr sexp_opaque;
@@ -84,7 +84,7 @@ let init ?src ?(tls_server_key=`None) () =
 
 let connect ~ctx (mode:client) =
   match mode with
-  | `OpenSSL (_host, ip, port) -> 
+  | `OpenSSL (_host, ip, port) ->
 IFDEF HAVE_LWT_SSL THEN
       let sa = Unix.ADDR_INET (Ipaddr_unix.to_inet_addr ip,port) in
       lwt fd, ic, oc = Conduit_lwt_unix_net_ssl.Client.connect ?src:ctx.src sa in
@@ -115,7 +115,7 @@ let serve ?timeout ?stop ~(ctx:ctx) ~(mode:server) callback =
   Lwt.on_cancel t (fun () -> print_endline "Terminating server thread");
   match mode with
   | `TCP (`Port port) ->
-       let sockaddr, ip = sockaddr_on_tcp_port ctx port in 
+       let sockaddr, ip = sockaddr_on_tcp_port ctx port in
        Conduit_lwt_unix_net.Sockaddr_server.init ~sockaddr ?timeout ?stop
          (fun fd ic oc -> callback (TCP {fd; ip; port}) ic oc);
        >>= fun () -> t
@@ -124,7 +124,7 @@ let serve ?timeout ?stop ~(ctx:ctx) ~(mode:server) callback =
        Conduit_lwt_unix_net.Sockaddr_server.init ~sockaddr ?timeout ?stop
          (fun fd ic oc -> callback (Domain_socket {fd;path}) ic oc);
        >>= fun () -> t
-  | `OpenSSL (`Crt_file_path certfile, `Key_file_path keyfile, pass, `Port port) -> 
+  | `OpenSSL (`Crt_file_path certfile, `Key_file_path keyfile, pass, `Port port) ->
 IFDEF HAVE_LWT_SSL THEN
        let sockaddr, ip = sockaddr_on_tcp_port ctx port in
        let password = match pass with |`No_password -> None |`Password fn -> Some fn in
@@ -142,6 +142,10 @@ type endp = [
   | `TLS of string * endp         (** Wrap in a TLS channel, [hostname,endp] *)
   | `Unknown of string            (** Failed resolution *)
 ] with sexp
+
+let endp_of_flow = function
+  | TCP { ip; port; _ } -> `TCP (ip, port)
+  | Domain_socket { path; _ } -> `Unix_domain_socket path
 
 (** Use the configuration of the server to interpret how to
     handle a particular endpoint from the resolver into a

--- a/lib/Conduit_lwt_unix.mli
+++ b/lib/Conduit_lwt_unix.mli
@@ -23,7 +23,7 @@ type client = [
 
 type server = [
   | `OpenSSL of
-      [ `Crt_file_path of string ] * 
+      [ `Crt_file_path of string ] *
       [ `Key_file_path of string ] *
       [ `Password of bool -> string | `No_password ] *
       [ `Port of int ]
@@ -39,7 +39,7 @@ type flow with sexp
 type tls_server_key = [
  | `None
  | `OpenSSL of
-    [ `Crt_file_path of string ] * 
+    [ `Crt_file_path of string ] *
     [ `Key_file_path of string ] *
     [ `Password of bool -> string | `No_password ]
 ]
@@ -54,6 +54,7 @@ val serve :
   ?timeout:int -> ?stop:(unit io) -> ctx:ctx ->
    mode:server -> (flow -> ic -> oc -> unit io) -> unit io
 
+val endp_of_flow : flow -> Conduit.endp
 val endp_to_client : ctx:ctx -> Conduit.endp -> client io
 val endp_to_server : ctx:ctx -> Conduit.endp -> server io
 


### PR DESCRIPTION
I add accessor to get sockaddr information (e.g. [Ocsigenserver](https://github.com/ocsigen/ocsigenserver/blob/3.0.0-cohttp/src/server/ocsigen_cohttp_server.ml#L59)) and remove blank :) ! I created an another function ([this](http://paste.isomorphis.me/qA4)) in intern of Ocsigenserver, but I think it's could be better in Conduit.
