### PR TITLE
If depopt dns is used, it must be at least 0.10.0

### DIFF
--- a/opam
+++ b/opam
@@ -31,5 +31,6 @@ conflicts: [
   "lwt" {<"2.4.3"}
   "async_ssl" {<"111.21.00"}
   "mirage-types" {<"2.0.0"}
+  "dns" {<"0.10.0"}
 ]
 available: [ocaml-version >= "4.01.0"]


### PR DESCRIPTION
findlib name dns.mirage minted for 0.10.0
