### PR TITLE
don't build the doc when pinning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all install clean
+.PHONY: all install clean doc github
 
 PREFIX ?= /usr/local/bin
  
@@ -11,7 +11,10 @@ install:
 clean:
 	rm -rf _build _install
 
-github:
+doc:
+	@BUILD_DOC=true ./build.sh
+
+github: doc
 	git checkout gh-pages
 	git merge master --no-edit
 	$(MAKE)

--- a/build.sh
+++ b/build.sh
@@ -124,8 +124,10 @@ if [ "$HAVE_VCHAN_LWT" != "" ]; then
 fi
 
 # Build all the ocamldoc
-cat lib/*.odocl > lib/conduit-all.odocl
-TARGETS="${TARGETS} lib/conduit-all.docdir/index.html"
+if [ "$BUILD_DOC" = "true" ]; then
+  cat lib/*.odocl > lib/conduit-all.odocl
+  TARGETS="${TARGETS} lib/conduit-all.docdir/index.html"
+fi
 
 REQS=`echo $PKG $ASYNC_REQUIRES $LWT_REQUIRES $LWT_UNIX_REQUIRES $LWT_MIRAGE_REQUIRES $LWT_MIRAGE_XEN_REQUIRES $VCHAN_LWT_REQUIRES | tr -s ' '`
 


### PR DESCRIPTION
use an environment variable BUILD_DOC=true to trigger ocamlbuild doc gen

Avoids lpw25/doc-ock-lib#20 and unnecessary doc rebuilds.
