### PR TITLE
Add temporary error_message function

### DIFF
--- a/lib/conduit_mirage.ml
+++ b/lib/conduit_mirage.ml
@@ -44,6 +44,11 @@ module Make_flow(S:V1_LWT.TCPV4)(V:VCHAN_FLOW) = struct
   type 'a io = 'a Lwt.t
   type error = [ `Refused | `Timeout | `Unknown of string ]
 
+  let error_message = function
+  | `Refused -> "Refused"
+  | `Timeout -> "Timeout"
+  | `Unknown msg -> msg
+
   type buffer = Cstruct.t
 
   type flow =


### PR DESCRIPTION
This allows the V1.FLOW signature to be updated without breaking
conduit. It can then be replaced by the version in https://github.com/mirage/ocaml-conduit/pull/37.