### PR TITLE
Bypass unsupported ocamldoc for polymorphic variants

### DIFF
--- a/lib/conduit_lwt_unix.mli
+++ b/lib/conduit_lwt_unix.mli
@@ -44,7 +44,7 @@ with sexp
    - [`Vchan_direct (`Domid domid, `Port port)]: Connect to the remote
      VM on the [domid], [port] tuple.
    - [`Vchan_domain_socket (`Domain_name domain, `Port port_name)]:
-     Use the Vchan name resolution to connect )
+     Use the Vchan name resolution to connect.
 
  *)
 type client = [

--- a/lib/conduit_lwt_unix.mli
+++ b/lib/conduit_lwt_unix.mli
@@ -30,11 +30,25 @@ type client_tls_config =
   [ `Port of int ]
 with sexp
 
-(** Set of supported client connections that are supported by this module. *)
+(** Set of supported client connections that are supported by this module:
+
+   - [`TLS (`Hostname host, `IP ip, `Port port)]: Use OCaml-TLS or
+     OpenSSL (depending on CONDUIT_TLS) to connect to
+      the given [host], [ip], [port] tuple via TCP.
+   - [`TLS_native _]: Force use of native OCaml TLS stack to connect.
+   - [`OpenSSL _]: Force use of Lwt OpenSSL bindings to connect.
+   - [`TCP (`IP ip, `Port port)]: Use TCP to connect to the given
+     [ip], [port] tuple.
+   - [`Unix_domain_socket (`File path)]: Use UNIX domain sockets to
+     connect to a socket on the [path].
+   - [`Vchan_direct (`Domid domid, `Port port)]: Connect to the remote
+     VM on the [domid], [port] tuple.
+   - [`Vchan_domain_socket (`Domain_name domain, `Port port_name)]:
+     Use the Vchan name resolution to connect )
+
+ *)
 type client = [
   | `TLS of client_tls_config
-  (** Use OCaml-TLS or OpenSSL (depending on CONDUIT_TLS) to connect to
-      the given [host], [ip], [port] tuple via TCP *)
   | `TLS_native of client_tls_config
   (** Force use of native OCaml TLS stack to connect.*)
   | `OpenSSL of client_tls_config


### PR DESCRIPTION

Fixing #85, the old school way.

<img width="1157" alt="screenshot 2015-07-26 11 20 46" src="https://cloud.githubusercontent.com/assets/617111/8894547/72753fa4-3388-11e5-946a-f0e1deccd3ec.png">
