### PR TITLE
`Conduit_lwt_unix.Serve` now passes the client `flow` to the server

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,9 @@
-0.8.7 (trunk)
+0.8.7 (2015-08-18):
 * Do not ignore custom context when calling `Conduit_lwt_unix_ssl.accept`
   (reported by @jrb467 in #88)
+* `Conduit_lwt_unix.Serve` now passes the client `flow` to the server
+  callback instead of the listening server one.  This lets servers
+  retrieve the peer endpoint correctly (reported by @fxfactorial in #87)
 
 0.8.6 (2015-07-14)
 * Add a `Conduit_mirage.Context`, a functor for creating HTTP(s) conduit

--- a/lib/conduit_lwt_unix.mli
+++ b/lib/conduit_lwt_unix.mli
@@ -147,7 +147,10 @@ val connect : ctx:ctx -> client -> (flow * ic * oc) io
     connection of type [mode], using the [ctx] context.  The
     [stop] thread will terminate the server if it ever becomes
     determined.  Every connection will be served in a new
-    lightweight thread that is invoked via the [fn] callback *)
+    lightweight thread that is invoked via the [fn] callback.
+    The [fn] callback is passed the {!flow} representing the
+    client connection and the associated input {!ic} and output
+    {!oc} channels. *)
 val serve :
   ?timeout:int -> ?stop:(unit io) -> ctx:ctx ->
    mode:server -> (flow -> ic -> oc -> unit io) -> unit io


### PR DESCRIPTION
callback instead of the listening server one.  This lets servers
retrieve the peer endpoint correctly.

Closes #87