### PR TITLE
Backport the logic from the mirage dsl

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,3 +1,4 @@
 PKG sexplib stringext uri cstruct ipaddr lwt vchan async_ssl tls tls.lwt
+PKG dns.mirage mirage-types
 B _build/**
 S lib/

--- a/lib/conduit_mirage.mli
+++ b/lib/conduit_mirage.mli
@@ -124,6 +124,10 @@ module type S = sig
   val empty: t
   (** The empty conduit. *)
 
+  module With_tcp (S:V1_LWT.STACKV4) : sig
+    val connect : S.t -> t -> t Lwt.t
+  end
+
   val with_tcp: t -> 'a stackv4 -> 'a -> t Lwt.t
   (** Extend a conduit with an implementation for TCP. *)
 


### PR DESCRIPTION
- Add a Make_with_stack convenience functor for dns resolver.
  This functor combination was [hardcoded in mirage DSL](https://github.com/mirage/mirage/blob/cd92d39eefda34e73fcd0d365afc6b5be62e78bf/lib/mirage.ml#L1832-L1836).

- Add the With_tcp functor
  As discussed [here](https://github.com/mirage/mirage/pull/441#issuecomment-133758606), I was not happy with the initialization scheme.
  This functor allow to have a more mirage-like init scheme. The resulting combinators can be seen [here](https://github.com/Drup/mirage/blob/9257f1a6038fb5dd0007d7a7afad480a4b634da6/lib/mirage.ml#L898-L972).
  A `conduit_connector` is a module that posses a method connect of type `Conduit_mirage.t -> Conduit_mirage.t Lwt.t`, which allow easy chaining.
  Notice the general `conduit_with_connectors` combinator which takes any connectors and just chain them. Given this, it is possible to add connectors rather independently.
  Here is the resulting generated code:

```ocaml
module F3 = Conduit_mirage.With_tcp(F2)

let tcp_conduit_connector1 () =
  stackv411 () >>= function
  | `Error _e -> fail (Failure "stackv411")
  | `Ok _stackv411 ->
  let f = F3.connect _stackv411 in return (`Ok f)

let nocrypto () =
  Nocrypto_entropy_lwt.initialize () >|= fun x -> `Ok x

let tls_conduit_connector () =
  nocrypto () >>= function
  | `Error _e -> fail (Failure "nocrypto")
  | `Ok _nocrypto ->
  return (`Ok Conduit_mirage.with_tls)

let conduit1 () =
  tcp_conduit_connector1 () >>= function
  | `Error _e -> fail (Failure "tcp_conduit_connector1")
  | `Ok _tcp_conduit_connector1 ->
  tls_conduit_connector () >>= function
  | `Error _e -> fail (Failure "tls_conduit_connector")
  | `Ok _tls_conduit_connector ->
  Lwt.return Conduit_mirage.empty >>= _tcp_conduit_connector1 >>=
_tls_conduit_connector >>=
fun t -> Lwt.return (`Ok t)
```