### PR TITLE
Expose a ?version arg in Conduit_async_ssl.ssl_listen, default being …

### DIFF
--- a/lib/conduit_async_ssl.ml
+++ b/lib/conduit_async_ssl.ml
@@ -33,12 +33,13 @@ let ssl_connect net_to_ssl ssl_to_net =
   >>| fun (app_wr,_) ->
   app_rd, app_wr
 
-let ssl_listen ~crt_file ~key_file rd wr =
+let ssl_listen ?(version=Ssl.Version.Tlsv1_2) ~crt_file ~key_file rd wr =
   let net_to_ssl = Reader.pipe rd in
   let ssl_to_net = Writer.pipe wr in
   let app_to_ssl, app_wr = Pipe.create () in
   let app_rd, ssl_to_app = Pipe.create () in
   let server = Ssl.server
+    ~version
     ~crt_file
     ~key_file
     ~app_to_ssl

--- a/lib/conduit_async_ssl.mli
+++ b/lib/conduit_async_ssl.mli
@@ -18,6 +18,7 @@
 
 (** TLS/SSL connection establishment using OpenSSL and Async *)
 open Async.Std
+open Async_ssl.Std
 
 (** [ssl_connect rd wr] will establish a client TLS/SSL session
     over an existing pair of a [rd] {!Reader.t} and [wd] {!Writer.t}
@@ -31,6 +32,7 @@ val ssl_connect :
     TLS/SSL session over an existing pair of [rd] {!Reader.t} and
     [wd] {!Writer.t} Async connections. *)
 val ssl_listen :
+  ?version:Ssl.Version.t ->
   crt_file:string ->
   key_file:string ->
   Reader.t ->


### PR DESCRIPTION
…the latest TLS version.