### PR TITLE
Support servers being started on-demand by launchd

### DIFF
--- a/META.in
+++ b/META.in
@@ -21,7 +21,7 @@ package "lwt" (
 package "lwt-unix" (
  version = "@VERSION@"
  description = "Resolve URIs into Lwt channels under Unix"
- requires = "conduit.lwt @LWT_UNIX_REQUIRES@ @VCHAN_LWT_REQUIRES@"
+ requires = "conduit.lwt @LWT_UNIX_REQUIRES@ @VCHAN_LWT_REQUIRES@ @LAUNCHD_LWT_REQUIRES@"
  archive(byte) = "conduit-lwt-unix.cma"
  archive(byte, plugin) = "conduit-lwt-unix.cma"
  archive(native) = "conduit-lwt-unix.cmxa"

--- a/build.sh
+++ b/build.sh
@@ -25,6 +25,7 @@ HAVE_MIRAGE=`ocamlfind query mirage-types dns.mirage 2>/dev/null || true`
 HAVE_MIRAGE_TLS=`ocamlfind query tls.mirage 2>/dev/null || true`
 HAVE_VCHAN=`ocamlfind query vchan 2>/dev/null || true`
 HAVE_VCHAN_LWT=`ocamlfind query vchan.lwt xen-evtchn.unix 2>/dev/null || true`
+HAVE_LAUNCHD_LWT=`ocamlfind query launchd.lwt 2>/dev/null || true`
 
 add_target () {
   TARGETS="$TARGETS lib/$1.cmxs lib/$1.cma lib/$1.cmxa"
@@ -124,13 +125,19 @@ if [ "$HAVE_VCHAN_LWT" != "" ]; then
     VCHAN_LWT_REQUIRES="vchan.lwt"
 fi
 
+if [ "$HAVE_LAUNCHD_LWT" != "" ]; then
+    echo "Building with Launchd Lwt_unix support."
+    echo 'true: define(HAVE_LAUNCHD_LWT)' >> _tags
+    LAUNCHD_LWT_REQUIRES="launchd.lwt"
+fi
+
 # Build all the ocamldoc
 if [ "$BUILD_DOC" = "true" ]; then
   cat lib/*.odocl > lib/conduit-all.odocl
   TARGETS="${TARGETS} lib/conduit-all.docdir/index.html"
 fi
 
-REQS=`echo $PKG $ASYNC_REQUIRES $LWT_REQUIRES $LWT_UNIX_REQUIRES $MIRAGE_REQUIRES $VCHAN_LWT_REQUIRES  | tr -s ' '`
+REQS=`echo $PKG $ASYNC_REQUIRES $LWT_REQUIRES $LWT_UNIX_REQUIRES $MIRAGE_REQUIRES $VCHAN_LWT_REQUIRES $LAUNCHD_LWT_REQUIRES | tr -s ' '`
 
 ocamlbuild -use-ocamlfind -classic-display -no-links -j ${J_FLAG} -tag ${TAGS} \
   -cflags "-w A-4-33-40-41-42-43-34-44" \
@@ -145,6 +152,7 @@ sed \
   -e "s/@LWT_UNIX_REQUIRES@/${LWT_UNIX_REQUIRES}/g" \
   -e "s/@MIRAGE_REQUIRES@/${MIRAGE_REQUIRES}/g" \
   -e "s/@VCHAN_LWT_REQUIRES@/${VCHAN_LWT_REQUIRES}/g" \
+  -e "s/@LAUNCHD_LWT_REQUIRES@/${LAUNCHD_LWT_REQUIRES}/g" \
   META.in > META
 
 if [ "$1" = "true" ]; then

--- a/lib/conduit_lwt_unix.mli
+++ b/lib/conduit_lwt_unix.mli
@@ -80,6 +80,7 @@ type server = [
   | `Unix_domain_socket of [ `File of string ]
   | `Vchan_direct of int * string
   | `Vchan_domain_socket of string  * string
+  | `Launchd of string
 ] with sexp
 
 type 'a io = 'a Lwt.t

--- a/opam
+++ b/opam
@@ -26,6 +26,7 @@ depopts: [
   "async_ssl"
   "mirage-dns"
   "vchan"
+  "launchd"
   "tls"
   "mirage-types-lwt"
 ]


### PR DESCRIPTION
In on-demand mode, launchd reads the .plist file and listens on the
specified Unix domain sockets / TCP ports / other things. When something
interesting happens, launchd will spawn the service and expect it to
call `launch_activate_sockets` to receive the listening sockets. The
client is expected to call `accept` on these sockets.

This is very similar to the existing socket server, except that launchd
is the one who creates and listens on the sockets.

Signed-off-by: David Scott <dave.scott@unikernel.com>