### PR TITLE
lwt/ocaml-tls server fix

### DIFF
--- a/lib/conduit_lwt_tls.ml
+++ b/lib/conduit_lwt_tls.ml
@@ -65,7 +65,7 @@ module Server = struct
     let events = match timeout with
       | None -> [c]
       | Some t -> [c; (Lwt_unix.sleep (float_of_int t)) ] in
-    Lwt.pick events
+    Lwt.ignore_result (Lwt.pick events)
 
   let init ?(nconn=20) ~certfile ~keyfile
         ?(stop = fst (Lwt.wait ())) ?timeout sa callback =
@@ -83,9 +83,7 @@ module Server = struct
       else (
         Lwt.catch
           (fun () ->
-             accept config s >>= fun accepted ->
-             Lwt.ignore_result (process_accept ~timeout callback accepted);
-             Lwt.return_unit)
+             accept config s >|= process_accept ~timeout callback)
           (function
             | Lwt.Canceled -> cont := false; return ()
             | _ -> return ())

--- a/lib/conduit_lwt_unix_ssl.ml
+++ b/lib/conduit_lwt_unix_ssl.ml
@@ -82,8 +82,7 @@ module Server = struct
     let events = match timeout with
       | None -> [c]
       | Some t -> [c; (Lwt_unix.sleep (float_of_int t)) ] in
-    let _ = Lwt.pick events >>= fun () -> close (ic,oc) in
-    return ()
+    Lwt.ignore_result (Lwt.pick events >>= fun () -> close (ic,oc))
 
   let init ?ctx ?(nconn=20) ?password ~certfile ~keyfile
     ?(stop = fst (Lwt.wait ())) ?timeout sa callback =
@@ -98,7 +97,7 @@ module Server = struct
       if not !cont then return_unit
       else (
         Lwt.catch
-          (fun () -> accept ?ctx s >>= process_accept ~timeout callback)
+          (fun () -> accept ?ctx s >|= process_accept ~timeout callback)
           (function
             | Lwt.Canceled -> cont := false; return_unit
             | _ -> return_unit)


### PR DESCRIPTION
Server in `Conduit_lwt_tls` waits for a user callback to finish before
accepting more connections. Instead, it should only wait until the
connection is accepted and detach the client callback

Fix #97