### PR TITLE
Support for Async SSL connection parameters

### DIFF
--- a/lib/conduit_async.ml
+++ b/lib/conduit_async.ml
@@ -45,11 +45,12 @@ ELSE
   type config = unit with sexp
 
   let verify_certificate connection =
-    let _ = connection in return true
+    let _ = connection in
+    raise (Failure "SSL unsupported")
 
   let configure ?version ?name ?ca_file ?ca_path ?session ?verify () =
     let _, _, _, _, _, _ = (version, name, ca_file, ca_path, session, verify) in
-    ()
+    raise (Failure "SSL unsupported")
 END
 end
 

--- a/lib/conduit_async.ml
+++ b/lib/conduit_async.ml
@@ -33,10 +33,19 @@ IFDEF HAVE_ASYNC_SSL THEN
     verify : (Ssl.Connection.t -> bool Deferred.t) option;
   } with sexp
 
+  let verify_certificate connection =
+    match Ssl.Connection.peer_certificate connection with
+    | None -> return false
+    | Some (Error _) -> return false
+    | Some (Ok _) -> return true
+
   let configure ?version ?name ?ca_file ?ca_path ?session ?verify () =
     { version; name; ca_file; ca_path; session; verify}
 ELSE
   type config = unit with sexp
+
+  let verify_certificate connection =
+    let _ = connection in return true
 
   let configure ?version ?name ?ca_file ?ca_path ?session ?verify () =
     let _, _, _, _, _, _ = (version, name, ca_file, ca_path, session, verify) in

--- a/lib/conduit_async.ml
+++ b/lib/conduit_async.ml
@@ -30,15 +30,16 @@ IFDEF HAVE_ASYNC_SSL THEN
     ca_file : string option;
     ca_path : string option;
     session : Ssl.Session.t option sexp_opaque;
+    verify : (Ssl.Connection.t -> bool Deferred.t) option;
   } with sexp
 
-  let configure ?version ?name ?ca_file ?ca_path ?session () =
-    { version; name; ca_file; ca_path; session}
+  let configure ?version ?name ?ca_file ?ca_path ?session ?verify () =
+    { version; name; ca_file; ca_path; session; verify}
 ELSE
   type config = unit with sexp
 
-  let configure ?version ?name ?ca_file ?ca_path ?session () =
-    let _, _, _, _, _ = (version, name, ca_file, ca_path, session) in
+  let configure ?version ?name ?ca_file ?ca_path ?session ?verify () =
+    let _, _, _, _, _, _ = (version, name, ca_file, ca_path, session, verify) in
     ()
 END
 end
@@ -74,8 +75,8 @@ IFDEF HAVE_ASYNC_SSL THEN
       Tcp.connect ?interrupt (Tcp.to_host_and_port (Ipaddr.to_string ip) port)
       >>= fun (_, rd, wr) ->
       let open Ssl in
-      match config with | {version; name; ca_file; ca_path; session} ->
-      Conduit_async_ssl.ssl_connect ?version ?name ?ca_file ?ca_path ?session rd wr
+      match config with | {version; name; ca_file; ca_path; session; verify} ->
+      Conduit_async_ssl.ssl_connect ?version ?name ?ca_file ?ca_path ?session ?verify rd wr
 ELSE
       raise (Failure "SSL unsupported")
 END

--- a/lib/conduit_async.mli
+++ b/lib/conduit_async.mli
@@ -35,6 +35,7 @@ IFDEF HAVE_ASYNC_SSL THEN
     ?ca_file:string ->
     ?ca_path:string ->
     ?session:Ssl.Session.t ->
+    ?verify:(Ssl.Connection.t -> bool Deferred.t) ->
     unit ->
     config
 ELSE
@@ -44,6 +45,7 @@ ELSE
     ?ca_file:string ->
     ?ca_path:string ->
     ?session:'e ->
+    ?verify:'f ->
     unit ->
     config
 END

--- a/lib/conduit_async.mli
+++ b/lib/conduit_async.mli
@@ -21,12 +21,41 @@
 open Core.Std
 open Async.Std
 
+IFDEF HAVE_ASYNC_SSL THEN
+open Async_ssl.Std
+END
+
+module Ssl : sig
+  type config
+
+IFDEF HAVE_ASYNC_SSL THEN
+  val configure :
+    ?version:Ssl.Version.t ->
+    ?name:string ->
+    ?ca_file:string ->
+    ?ca_path:string ->
+    ?session:Ssl.Session.t ->
+    unit ->
+    config
+ELSE
+  val configure :
+    ?version:'a ->
+    ?name:string ->
+    ?ca_file:string ->
+    ?ca_path:string ->
+    ?session:'e ->
+    unit ->
+    config
+END
+end
+
 type +'a io = 'a Deferred.t
 type ic = Reader.t
 type oc = Writer.t
 
 type addr = [
   | `OpenSSL of string * Ipaddr.t * int
+  | `OpenSSL_with_config of string * Ipaddr.t * int * Ssl.config
   | `TCP of Ipaddr.t * int
   | `Unix_domain_socket of string
 ] with sexp

--- a/lib/conduit_async.mli
+++ b/lib/conduit_async.mli
@@ -29,6 +29,10 @@ module Ssl : sig
   type config
 
 IFDEF HAVE_ASYNC_SSL THEN
+  val verify_certificate :
+    Ssl.Connection.t ->
+    bool Deferred.t
+
   val configure :
     ?version:Ssl.Version.t ->
     ?name:string ->
@@ -39,6 +43,10 @@ IFDEF HAVE_ASYNC_SSL THEN
     unit ->
     config
 ELSE
+  val verify_certificate :
+    'a ->
+    bool Deferred.t
+
   val configure :
     ?version:'a ->
     ?name:string ->

--- a/lib/conduit_async_ssl.ml
+++ b/lib/conduit_async_ssl.ml
@@ -20,13 +20,23 @@ open Core.Std
 open Async.Std
 open Async_ssl.Std
 
-let ssl_connect ?version ?name ?ca_file ?ca_path ?session net_to_ssl ssl_to_net =
+let ssl_connect ?version ?name ?ca_file ?ca_path ?session ?verify
+                net_to_ssl ssl_to_net =
   let net_to_ssl = Reader.pipe net_to_ssl in
   let ssl_to_net = Writer.pipe ssl_to_net in
   let app_to_ssl, app_wr = Pipe.create () in
   let app_rd, ssl_to_app = Pipe.create () in
   let client =  Ssl.client ?version ?name ?ca_file ?ca_path ?session ~app_to_ssl ~ssl_to_app ~net_to_ssl ~ssl_to_net () in
-  don't_wait_for (client >>= fun _con -> return ());
+  let verify_connection = match verify with
+    | None -> fun _ -> return true
+    | Some f -> f
+  in
+  client >>= function
+  | Error err -> Error.raise err
+  | Ok con -> verify_connection con
+  >>= function
+  | false -> failwith "Connection verification failed."
+  | true ->
   Reader.of_pipe (Info.of_string "async_conduit_ssl_reader") app_rd
   >>= fun app_rd ->
   Writer.of_pipe (Info.of_string "async_conduit_ssl_writer") app_wr

--- a/lib/conduit_async_ssl.ml
+++ b/lib/conduit_async_ssl.ml
@@ -20,12 +20,12 @@ open Core.Std
 open Async.Std
 open Async_ssl.Std
 
-let ssl_connect net_to_ssl ssl_to_net =
+let ssl_connect ?version ?name ?ca_file ?ca_path ?session net_to_ssl ssl_to_net =
   let net_to_ssl = Reader.pipe net_to_ssl in
   let ssl_to_net = Writer.pipe ssl_to_net in
   let app_to_ssl, app_wr = Pipe.create () in
   let app_rd, ssl_to_app = Pipe.create () in
-  let client =  Ssl.client ~app_to_ssl ~ssl_to_app ~net_to_ssl ~ssl_to_net () in
+  let client =  Ssl.client ?version ?name ?ca_file ?ca_path ?session ~app_to_ssl ~ssl_to_app ~net_to_ssl ~ssl_to_net () in
   don't_wait_for (client >>= fun _con -> return ());
   Reader.of_pipe (Info.of_string "async_conduit_ssl_reader") app_rd
   >>= fun app_rd ->

--- a/lib/conduit_async_ssl.mli
+++ b/lib/conduit_async_ssl.mli
@@ -24,6 +24,11 @@ open Async_ssl.Std
     over an existing pair of a [rd] {!Reader.t} and [wd] {!Writer.t}
     Async connections. *)
 val ssl_connect :
+  ?version:Ssl.Version.t ->
+  ?name:string ->
+  ?ca_file:string ->
+  ?ca_path:string ->
+  ?session:Ssl.Session.t ->
   Reader.t ->
   Writer.t ->
   (Reader.t * Writer.t) Deferred.t

--- a/lib/conduit_async_ssl.mli
+++ b/lib/conduit_async_ssl.mli
@@ -17,6 +17,7 @@
 *)
 
 (** TLS/SSL connection establishment using OpenSSL and Async *)
+open Core.Std
 open Async.Std
 open Async_ssl.Std
 
@@ -29,6 +30,7 @@ val ssl_connect :
   ?ca_file:string ->
   ?ca_path:string ->
   ?session:Ssl.Session.t ->
+  ?verify:(Ssl.Connection.t -> bool Deferred.t) ->
   Reader.t ->
   Writer.t ->
   (Reader.t * Writer.t) Deferred.t


### PR DESCRIPTION
This pull requests adds support for Async SSL connection parameters, e.g. a CA certificate file.

The pull request maintains a backwards compatible interface and allows compilation without support for SSL.