### PR TITLE
Ssl leak / EMFILE / TLSv1.2 fixes

### DIFF
--- a/lib/conduit_lwt_tls.ml
+++ b/lib/conduit_lwt_tls.ml
@@ -25,7 +25,8 @@ let safe_close t =
     (fun _ -> return_unit)
 
 let close (ic, oc) =
-  Lwt.join [ safe_close oc; safe_close ic ]
+  safe_close oc >>= fun () ->
+  safe_close ic
 
 let with_socket sockaddr f =
   let fd = Lwt_unix.socket (Unix.domain_of_sockaddr sockaddr) Unix.SOCK_STREAM 0 in

--- a/lib/conduit_lwt_tls.ml
+++ b/lib/conduit_lwt_tls.ml
@@ -94,7 +94,7 @@ module Server = struct
              accept config s >|= process_accept ~timeout callback)
           (function
             | Lwt.Canceled -> cont := false; return ()
-            | _ -> return ())
+            | _ -> Lwt_unix.yield ())
         >>= loop
       )
     in

--- a/lib/conduit_lwt_unix_ssl.ml
+++ b/lib/conduit_lwt_unix_ssl.ml
@@ -44,7 +44,8 @@ let with_socket sockaddr f =
 
 module Client = struct
   (* SSL TCP connection *)
-  let t = Ssl.create_context Ssl.TLSv1 Ssl.Client_context
+  let t = Ssl.create_context Ssl.SSLv23 Ssl.Client_context
+  let () = Ssl.disable_protocols t [Ssl.SSLv23]
 
   let connect ?(ctx=t) ?src sa =
     with_socket sa (fun fd ->
@@ -61,7 +62,8 @@ end
 
 module Server = struct
 
-  let t = Ssl.create_context Ssl.TLSv1 Ssl.Server_context
+  let t = Ssl.create_context Ssl.SSLv23 Ssl.Server_context
+  let () = Ssl.disable_protocols t [Ssl.SSLv23]
 
   let accept ?(ctx=t) fd =
     Lwt_unix.accept fd >>= fun (afd, _) ->

--- a/lib/conduit_lwt_unix_ssl.ml
+++ b/lib/conduit_lwt_unix_ssl.ml
@@ -100,7 +100,7 @@ module Server = struct
           (fun () -> accept ?ctx s >|= process_accept ~timeout callback)
           (function
             | Lwt.Canceled -> cont := false; return_unit
-            | _ -> return_unit)
+            | _ -> Lwt_unix.yield ())
         >>= loop
       )
     in

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -9,3 +9,6 @@ mirage:
 
 async:
 	make -C async
+
+unix:
+	make -C unix

--- a/tests/unix/.gitignore
+++ b/tests/unix/.gitignore
@@ -1,0 +1,3 @@
+server.conf
+server.key
+server.pem

--- a/tests/unix/Makefile
+++ b/tests/unix/Makefile
@@ -1,0 +1,4 @@
+clean:
+	ocamlbuild -clean
+cdtest.native: cdtest.ml
+	ocamlbuild ./cdtest.native -use-ocamlfind -tag 'package(conduit.lwt-unix)' -tag debug

--- a/tests/unix/cdtest.ml
+++ b/tests/unix/cdtest.ml
@@ -1,0 +1,53 @@
+(*
+ * Copyright (c) 2016 Skylable Ltd. <info-copyright@skylable.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*)
+
+open Lwt
+
+let port = 9192
+let config = `Crt_file_path "server.pem", `Key_file_path "server.key", `No_password, `Port port
+
+let rec repeat n f =
+  if n = 0 then return_unit
+  else f () >>= fun () -> repeat (n-1) f
+
+let perform () =
+  let stop, do_stop = Lwt.wait () in
+  Conduit_lwt_unix.init ~src:"127.0.0.1" () >>= fun ctx ->
+  let _ =
+    Conduit_lwt_unix.serve ~stop ~ctx ~mode:(`TLS config) (fun  _ ic oc ->
+        Lwt_io.read ic >>= fun _ -> Lwt_io.write oc "foo"  >>= fun () -> Lwt_io.flush oc)
+  in
+  let sa = Unix.ADDR_INET (Unix.inet_addr_loopback, port) in
+  let client_test () =
+    (* connect using low-level operations to check what happens if client closes connection
+       without calling ssl_shutdown (e.g. TCP connection is lost) *)
+    let s = Lwt_unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
+    let ctx = Ssl.create_context Ssl.TLSv1 Ssl.Client_context in
+    Lwt_unix.with_timeout 1. (fun () ->
+        Lwt.finalize (fun () ->
+            Lwt_unix.connect s sa >>= fun () ->
+            Lwt_ssl.ssl_connect s ctx >>= fun ss ->
+            return_unit)
+          (fun () -> Lwt_unix.close s))
+  in
+  repeat 1024 client_test >>= fun () ->
+  Lwt.wakeup do_stop ();
+  return_unit
+
+let () =
+  Lwt.async_exception_hook := ignore;
+  Lwt_main.run (Lwt_unix.handle_unix_error perform ());
+  print_endline "OK"

--- a/tests/unix/cdtest.ml
+++ b/tests/unix/cdtest.ml
@@ -35,7 +35,7 @@ let perform () =
     (* connect using low-level operations to check what happens if client closes connection
        without calling ssl_shutdown (e.g. TCP connection is lost) *)
     let s = Lwt_unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
-    let ctx = Ssl.create_context Ssl.TLSv1 Ssl.Client_context in
+    let ctx = Ssl.create_context Ssl.TLSv1_2 Ssl.Client_context in
     Lwt_unix.with_timeout 1. (fun () ->
         Lwt.finalize (fun () ->
             Lwt_unix.connect s sa >>= fun () ->

--- a/tests/unix/run.sh
+++ b/tests/unix/run.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+set -e
+set -o nounset
+cat >server.conf <<EOF
+[ req ]
+default_bits		= 2048
+distinguished_name	= req_distinguished_name
+prompt			= no
+encrypt_key		= no
+x509_extensions		= v3_ca
+
+[ req_distinguished_name ]
+CN		       = localhost
+
+[ CA_default ]
+copy_extensions = copy
+
+[ alternate_names ]
+DNS.2=localhost
+
+[ v3_ca ]
+subjectAltName=@alternate_names
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid:always,issuer:always
+basicConstraints = critical,CA:true
+keyUsage=keyCertSign,cRLSign,digitalSignature,keyEncipherment,nonRepudiation
+EOF
+
+openssl req -days 1 -x509 -config server.conf -new -keyout server.key -out server.pem
+make clean
+make cdtest.native
+./cdtest.native

--- a/tests/unix/server.conf
+++ b/tests/unix/server.conf
@@ -1,0 +1,22 @@
+[ req ]
+default_bits		= 2048
+distinguished_name	= req_distinguished_name
+prompt			= no
+encrypt_key		= no
+x509_extensions		= v3_ca
+
+[ req_distinguished_name ]
+CN		       = localhost
+
+[ CA_default ]
+copy_extensions = copy
+
+[ alternate_names ]
+DNS.2=localhost
+
+[ v3_ca ]
+subjectAltName=@alternate_names
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid:always,issuer:always
+basicConstraints = critical,CA:true
+keyUsage=keyCertSign,cRLSign,digitalSignature,keyEncipherment,nonRepudiation


### PR DESCRIPTION
Small self-contained fixes for #113, #102  and workaround for #109, and a test that can be run with `tests/unix/run.sh`.
It is not integrated with Travis, not sure how to do that or if it should be integrated at all.