### PR TITLE
Port to ppx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ _install/
 *.native
 *.byte
 *.xl
+ppx
+*.mlh

--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,16 @@
 
 PREFIX ?= /usr/local/bin
 
-all:
+all: ppx
 	@./build.sh
 
-install:
+install: ppx
 	@./build.sh true
 
 clean:
-	rm -rf _build _install
+	rm -rf _build _install ppx lib/conduit_config.mlh
 
-doc:
+doc: ppx
 	@BUILD_DOC=true ./build.sh
 
 github: doc
@@ -39,3 +39,7 @@ release:
 pr:
 	opam publish prepare $(NAME).$(VERSION) $(ARCHIVE)
 	OPAMYES=1 opam publish submit $(NAME).$(VERSION) && rm -rf $(NAME).$(VERSION)
+
+ppx:
+	ocamlfind ocamlopt -predicates ppx_driver -o ppx -linkpkg \
+	  -package ppx_sexp_conv ppx_driver_runner.cmxa

--- a/build.sh
+++ b/build.sh
@@ -68,7 +68,6 @@ if [ "$HAVE_ASYNC" != "" ]; then
 
   if [ "$HAVE_ASYNC_SSL" != "" ]; then
     echo "Building with Async/SSL support."
-    echo 'true: define(HAVE_ASYNC_SSL)' >> _tags
     ASYNC_REQUIRES="$ASYNC_REQUIRES async_ssl"
     echo Conduit_async_ssl >> lib/conduit-async.mllib
   fi
@@ -89,14 +88,12 @@ if [ "$HAVE_LWT" != "" ]; then
 
   if [ "$HAVE_LWT_SSL" != "" ]; then
     echo "Building with Lwt/SSL support."
-    echo 'true: define(HAVE_LWT_SSL)' >> _tags
     LWT_UNIX_REQUIRES="$LWT_UNIX_REQUIRES lwt.ssl"
     echo Conduit_lwt_unix_ssl >> lib/conduit-lwt-unix.mllib
   fi
 
   if [ "$HAVE_LWT_TLS" != "" ]; then
     echo "Building with Lwt/TLS support."
-    echo 'true: define(HAVE_LWT_TLS)' >> _tags
     LWT_UNIX_REQUIRES="$LWT_UNIX_REQUIRES tls tls.lwt"
     echo Conduit_lwt_tls >> lib/conduit-lwt-unix.mllib
   fi
@@ -106,20 +103,17 @@ if [ "$HAVE_LWT" != "" ]; then
 
   if [ "$HAVE_MIRAGE" != "" ]; then
     echo "Building with Mirage support."
-    echo 'true: define(HAVE_MIRAGE)' >> _tags
     echo Conduit_mirage > lib/conduit-lwt-mirage.mllib
     echo Resolver_mirage >> lib/conduit-lwt-mirage.mllib
     MIRAGE_REQUIRES="mirage-types dns.mirage uri.services"
     if [ "$HAVE_VCHAN" != "" ]; then
       echo "Building with Mirage Vchan support."
-      echo 'true: define(HAVE_VCHAN)' >> _tags
       MIRAGE_REQUIRES="$MIRAGE_REQUIRES vchan"
       echo Conduit_xenstore >> lib/conduit-lwt-mirage.mllib
       echo '"scripts/xenstore-conduit-init" {"xenstore-conduit-init"}' > _install/bin
     fi
     if [ "$HAVE_MIRAGE_TLS" != "" ]; then
       echo "Building with Mirage TLS support."
-      echo 'true: define(HAVE_MIRAGE_TLS)' >> _tags
       MIRAGE_REQUIRES="$MIRAGE_REQUIRES tls tls.mirage"
     fi
     add_target "conduit-lwt-mirage"
@@ -130,13 +124,11 @@ fi
 
 if [ "$HAVE_VCHAN_LWT" != "" ]; then
     echo "Building with Vchan Lwt_unix support."
-    echo 'true: define(HAVE_VCHAN_LWT)' >> _tags
     VCHAN_LWT_REQUIRES="vchan.lwt"
 fi
 
 if [ "$HAVE_LAUNCHD_LWT" != "" ]; then
     echo "Building with Launchd Lwt_unix support."
-    echo 'true: define(HAVE_LAUNCHD_LWT)' >> _tags
     LAUNCHD_LWT_REQUIRES="launchd.lwt"
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -4,20 +4,9 @@ TAGS=principal,annot,bin_annot,short_paths,thread,strict_sequence
 J_FLAG=2
 
 BASE_PKG="sexplib ipaddr cstruct uri stringext"
-SYNTAX_PKG="camlp4.macro pa_sexp_conv"
 
-# The Async backend is only supported in OCaml 4.01.0+
-OCAML_VERSION=`ocamlc -version`
-case $OCAML_VERSION in
-4.01.*|4.00.*|3.*)
-  echo Minimum OCaml version is 4.02
-  ;;
-*)
 HAVE_ASYNC=`ocamlfind query async 2>/dev/null || true`
 HAVE_ASYNC_SSL=`ocamlfind query async_ssl 2>/dev/null || true`
-;;
-esac
-
 HAVE_LWT=`ocamlfind query lwt 2>/dev/null || true`
 HAVE_LWT_SSL=`ocamlfind query lwt.ssl 2>/dev/null || true`
 HAVE_LWT_TLS=`ocamlfind query tls.lwt 2>/dev/null || true`
@@ -35,7 +24,28 @@ add_pkg () {
   PKG="$PKG $1"
 }
 
-add_pkg "$SYNTAX_PKG"
+CONDUIT_CONFIG=""
+mlh_exp() {
+  if [ "$1" != "" ]; then
+    CONDUIT_CONFIG="$CONDUIT_CONFIG\n#let $2 = true"
+  else
+    CONDUIT_CONFIG="$CONDUIT_CONFIG\n#let $2 = false"
+  fi
+}
+
+mlh_exp "$HAVE_ASYNC" HAVE_ASYNC
+mlh_exp "$HAVE_ASYNC_SSL" HAVE_ASYNC_SSL
+mlh_exp "$HAVE_LWT" HAVE_LWT
+mlh_exp "$HAVE_LWT_SSL" HAVE_LWT_SSL
+mlh_exp "$HAVE_LWT_TLS" HAVE_LWT_TLS
+mlh_exp "$HAVE_MIRAGE" HAVE_MIRAGE
+mlh_exp "$HAVE_MIRAGE_TLS" HAVE_MIRAGE_TLS
+mlh_exp "$HAVE_VCHAN" HAVE_VCHAN
+mlh_exp "$HAVE_VCHAN_LWT" HAVE_VCHAN_LWT
+mlh_exp "$HAVE_LAUNCHD_LWT" HAVE_LAUNCHD_LWT
+
+echo $CONDUIT_CONFIG > lib/conduit_config.mlh
+
 add_pkg "$BASE_PKG"
 add_target "conduit"
 rm -f lib/*.odocl
@@ -48,7 +58,7 @@ rm -f _tags
 rm -rf _install
 mkdir -p _install
 
-echo 'true: syntax(camlp4o)' >> _tags
+echo 'true: pp(/Users/rgrinberg/reps/ml/ocaml-conduit/ppx)' >> _tags
 
 if [ "$HAVE_ASYNC" != "" ]; then
   echo "Building with Async support."

--- a/build.sh
+++ b/build.sh
@@ -24,12 +24,11 @@ add_pkg () {
   PKG="$PKG $1"
 }
 
-CONDUIT_CONFIG=""
 mlh_exp() {
   if [ "$1" != "" ]; then
-    CONDUIT_CONFIG="$CONDUIT_CONFIG\n#let $2 = true"
+    echo "#let $2 = true" >> lib/conduit_config.mlh
   else
-    CONDUIT_CONFIG="$CONDUIT_CONFIG\n#let $2 = false"
+    echo "#let $2 = false" >> lib/conduit_config.mlh
   fi
 }
 
@@ -44,8 +43,6 @@ mlh_exp "$HAVE_VCHAN" HAVE_VCHAN
 mlh_exp "$HAVE_VCHAN_LWT" HAVE_VCHAN_LWT
 mlh_exp "$HAVE_LAUNCHD_LWT" HAVE_LAUNCHD_LWT
 
-echo $CONDUIT_CONFIG > lib/conduit_config.mlh
-
 add_pkg "$BASE_PKG"
 add_target "conduit"
 rm -f lib/*.odocl
@@ -58,7 +55,9 @@ rm -f _tags
 rm -rf _install
 mkdir -p _install
 
-echo 'true: pp(/Users/rgrinberg/reps/ml/ocaml-conduit/ppx)' >> _tags
+echo "true: config" >> _tags
+
+echo "true: pp($(pwd)/ppx)" >> _tags
 
 if [ "$HAVE_ASYNC" != "" ]; then
   echo "Building with Async support."

--- a/lib/conduit.ml
+++ b/lib/conduit.ml
@@ -26,7 +26,7 @@ type endp = [
   | `Vchan_domain_socket of string * string
   | `TLS of string * endp         (** wrap in a TLS channel, [hostname,endp] *)
   | `Unknown of string            (** failed resolution *)
-] with sexp
+] [@@deriving sexp]
 
 module type IO = sig
   type +'a t

--- a/lib/conduit.mli
+++ b/lib/conduit.mli
@@ -56,7 +56,7 @@ type endp = [
   | `Vchan_domain_socket of string * string (** Vchan Xen domain socket *)
   | `TLS of string * endp          (** Wrap in a TLS channel, [hostname,endp] *)
   | `Unknown of string             (** Failed resolution *)
-] with sexp
+] [@@deriving sexp]
 
 (** Module type for cooperative threading that can be satisfied by
     Lwt or Async *)

--- a/lib/conduit_async.mli
+++ b/lib/conduit_async.mli
@@ -17,20 +17,21 @@
 
 (** Connection establishment using the
     {{:https://github.com/janestreet/async}Async} library *)
+#import "conduit_config.mlh"
 
 open Core.Std
 open Async.Std
 
-exception Ssl_unsupported with sexp
+exception Ssl_unsupported [@@deriving sexp]
 
-IFDEF HAVE_ASYNC_SSL THEN
+#if HAVE_ASYNC_SSL
 open Async_ssl.Std
-END
+#endif
 
 module Ssl : sig
   type config
 
-IFDEF HAVE_ASYNC_SSL THEN
+#if HAVE_ASYNC_SSL
   val verify_certificate :
     Ssl.Connection.t ->
     bool Deferred.t
@@ -44,7 +45,7 @@ IFDEF HAVE_ASYNC_SSL THEN
     ?verify:(Ssl.Connection.t -> bool Deferred.t) ->
     unit ->
     config
-ELSE
+#else
   val verify_certificate :
     'a ->
     bool Deferred.t
@@ -58,7 +59,7 @@ ELSE
     ?verify:'f ->
     unit ->
     config
-END
+#endif
 end
 
 type +'a io = 'a Deferred.t
@@ -70,7 +71,7 @@ type addr = [
   | `OpenSSL_with_config of string * Ipaddr.t * int * Ssl.config
   | `TCP of Ipaddr.t * int
   | `Unix_domain_socket of string
-] with sexp
+] [@@deriving sexp]
 
 val connect : ?interrupt:unit io -> addr -> (ic * oc) io
 
@@ -80,20 +81,20 @@ type trust_chain =
   | `Search_file_first_then_path of
       [ `File of string ] *
       [ `Path of string ]
-  ] with sexp
+  ] [@@deriving sexp]
 
 type openssl =
   [ `OpenSSL of
       [ `Crt_file_path of string ] *
       [ `Key_file_path of string ]
-  ] with sexp
+  ] [@@deriving sexp]
 
 type server = [
   | openssl
   | `TCP
   | `OpenSSL_with_trust_chain of
       (openssl * trust_chain)
-] with sexp
+] [@@deriving sexp]
 
 val serve :
   ?max_connections:int ->

--- a/lib/conduit_lwt_unix.ml
+++ b/lib/conduit_lwt_unix.ml
@@ -16,7 +16,7 @@
  *
  *)
 
-#import "lib/conduit_config.mlh"
+#import "conduit_config.mlh"
 
 open Lwt
 open Sexplib.Conv

--- a/lib/conduit_lwt_unix.ml
+++ b/lib/conduit_lwt_unix.ml
@@ -16,7 +16,7 @@
  *
  *)
 
-#import "conduit_config.mlh"
+#import "lib/conduit_config.mlh"
 
 open Lwt
 open Sexplib.Conv

--- a/lib/conduit_lwt_unix.mli
+++ b/lib/conduit_lwt_unix.mli
@@ -28,7 +28,7 @@ type client_tls_config =
   [ `Hostname of string ] *
   [ `IP of Ipaddr.t ] *
   [ `Port of int ]
-with sexp
+[@@deriving sexp]
 
 (** Set of supported client connections that are supported by this module:
 
@@ -61,7 +61,7 @@ type client = [
   (** Connect to the remote VM on the [domid], [port] tuple. *)
   | `Vchan_domain_socket of [ `Domain_name of string ] * [ `Port of string ]
   (** Use the Vchan name resolution to connect *)
-] with sexp
+] [@@deriving sexp]
 
 (** Configuration fragment for a listening TLS server *)
 type server_tls_config =
@@ -69,7 +69,7 @@ type server_tls_config =
   [ `Key_file_path of string ] *
   [ `Password of bool -> string | `No_password ] *
   [ `Port of int ]
-with sexp
+[@@deriving sexp]
 
 (** Set of supported listening mechanisms that are supported by this module. 
    - [`TLS server_tls_config]: Use OCaml-TLS or OpenSSL (depending on CONDUIT_TLS) to connect
@@ -93,7 +93,7 @@ type server = [
   | `Vchan_direct of int * string
   | `Vchan_domain_socket of string  * string
   | `Launchd of string
-] with sexp
+] [@@deriving sexp]
 
 type 'a io = 'a Lwt.t
 type ic = Lwt_io.input_channel
@@ -104,21 +104,21 @@ type tcp_flow = private {
   fd: Lwt_unix.file_descr sexp_opaque;
   ip: Ipaddr.t;
   port: int;
-} with sexp_of
+} [@@deriving sexp_of]
 
 (** [domain_flow] contains the state of a single Unix domain socket
     connection. *)
 type domain_flow = private {
   fd: Lwt_unix.file_descr sexp_opaque;
   path: string;
-} with sexp_of
+} [@@deriving sexp_of]
 
 (** [vchan_flow] contains the state of a single Vchan shared memory
     connection. *)
 type vchan_flow = private {
   domid: int;
   port: string;
-} with sexp_of
+} [@@deriving sexp_of]
 
 (** A [flow] contains the state of a single connection, over a specific
     transport method. *)
@@ -126,7 +126,7 @@ type flow = private
   | TCP of tcp_flow
   | Domain_socket of domain_flow
   | Vchan of vchan_flow
-with sexp_of
+[@@deriving sexp_of]
 
 (** Type describing where to locate a PEM key in the filesystem *)
 type tls_server_key = [
@@ -135,10 +135,10 @@ type tls_server_key = [
     [ `Crt_file_path of string ] *
     [ `Key_file_path of string ] *
     [ `Password of bool -> string | `No_password ]
-] with sexp
+] [@@deriving sexp]
 
 (** State handler for an active conduit *)
-type ctx with sexp_of
+type ctx [@@deriving sexp_of]
 
 (** {2 Connection and listening} *)
 

--- a/lib/conduit_mirage.mli
+++ b/lib/conduit_mirage.mli
@@ -19,6 +19,7 @@
 (** Functorial connection establishment interface that is compatible with
     the Mirage libraries.
   *)
+#import "conduit_config.mlh"
 
 module Flow: V1_LWT.FLOW
 (** Dynamic flows. *)
@@ -32,10 +33,10 @@ module type Handler = sig
   type t
   (** The type for runtime handlers. *)
 
-  type client with sexp
+  type client [@@deriving sexp]
   (** The type for client configuration values. *)
 
-  type server with sexp
+  type server [@@deriving sexp]
   (** The type for server configuration values. *)
 
   val connect: t -> client -> Flow.flow Lwt.t
@@ -58,7 +59,7 @@ val stackv4: (module V1_LWT.STACKV4 with type t = 'a) -> 'a stackv4
 
 (** {1 VCHAN} *)
 
-IFDEF HAVE_VCHAN THEN
+#if HAVE_VCHAN
 
 type vchan_client = [
   | `Vchan of [
@@ -75,14 +76,14 @@ type vchan_server = [
 module type VCHAN = Vchan.S.ENDPOINT with type port = Vchan.Port.t
 module type XS = Xs_client_lwt.S
 
-ELSE
+#else
 
 type vchan_client = [`Vchan of [`None]]
 type vchan_server = [`Vchan of [`None]]
 module type VCHAN = sig type t end
 module type XS = sig end
 
-ENDIF
+#endif
 
 type vchan
 type xs
@@ -92,19 +93,19 @@ val xs: (module XS) -> xs
 
 (** {1 TLS} *)
 
-IFDEF HAVE_MIRAGE_TLS THEN
+#if HAVE_MIRAGE_TLS
 type 'a tls_client = [ `TLS of Tls.Config.client * 'a ]
 type 'a tls_server = [ `TLS of Tls.Config.server * 'a ]
-ELSE
+#else
 type 'a tls_client = [`TLS of [`None]]
 type 'a tls_server = [`TLS of [`None]]
-ENDIF
+#endif
 
 
-type client = [ tcp_client | vchan_client | client tls_client ] with sexp
+type client = [ tcp_client | vchan_client | client tls_client ] [@@deriving sexp]
 (** The type for client configuration values. *)
 
-type server = [ tcp_server | vchan_server | server tls_server ] with sexp
+type server = [ tcp_server | vchan_server | server tls_server ] [@@deriving sexp]
 (** The type for server configuration values. *)
 
 val client: Conduit.endp -> client Lwt.t

--- a/lib/conduit_trie.ml
+++ b/lib/conduit_trie.ml
@@ -19,7 +19,7 @@
 open Sexplib.Std
 
 type 'a t =
-  | Node of string * 'a option * 'a t list with sexp
+  | Node of string * 'a option * 'a t list [@@deriving sexp]
 
 (* Invariant: the only node with an empty string is the root *)
 let empty = Node("", None, [])

--- a/lib/conduit_trie.mli
+++ b/lib/conduit_trie.mli
@@ -19,7 +19,7 @@
 (** Radix tree that can do longest-prefix searches on string keys *)
 
 (** Radix tree that maps [string] keys to ['a] values *)
-type 'a t with sexp
+type 'a t [@@deriving sexp]
 
 (** An empty tree *)
 val empty : 'a t

--- a/lib/conduit_xenstore.ml
+++ b/lib/conduit_xenstore.ml
@@ -31,7 +31,7 @@ let err_port = fail "%s: invalid port"
 
 module Make (Xs: Xs_client_lwt.S) = struct
 
-  type t = { xs: Xs.client sexp_opaque; name: string } with sexp_of
+  type t = { xs: Xs.client sexp_opaque; name: string } [@@deriving sexp_of]
 
   let get_my_id xs = Xs.(immediate xs (fun h -> read h "domid"))
 

--- a/lib/resolver.ml
+++ b/lib/resolver.ml
@@ -21,7 +21,7 @@ type service = {
   name: string;
   port: int;
   tls: bool
-} with sexp
+} [@@deriving sexp]
 
 (** Module type for a {{!resolution}resolver} that can map URIs to
     concrete {{!Conduit.endp}endpoints} that stream connections can be
@@ -33,11 +33,11 @@ module type S = sig
   type +'a io
 
   (** State handle for a running resolver *)
-  type t with sexp
+  type t [@@deriving sexp]
 
   (** Abstract type for a service entry, which maps a URI scheme into
       a protocol handler and TCP port *)
-  type svc with sexp
+  type svc [@@deriving sexp]
 
   (** A rewrite function resolves a {{!svc}service} and a URI into
       a concrete endpoint. *)
@@ -83,19 +83,19 @@ end
 module Make(IO:Conduit.IO) = struct
   open IO
 
-  type svc = service with sexp
+  type svc = service [@@deriving sexp]
   type 'a io = 'a IO.t
 
   (** A rewrite modifies an input URI with more specialization
       towards a concrete [endp] *)
-  type rewrite_fn = service -> Uri.t -> Conduit.endp IO.t with sexp
-  type service_fn = string -> service option IO.t with sexp
+  type rewrite_fn = service -> Uri.t -> Conduit.endp IO.t [@@deriving sexp]
+  type service_fn = string -> service option IO.t [@@deriving sexp]
 
   type t = {
     default_lookup : rewrite_fn;
     mutable domains: rewrite_fn Conduit_trie.t;
     mutable service: service_fn;
-  } with sexp
+  } [@@deriving sexp]
 
   let default_lookup _ uri =
     (* TODO log *)

--- a/lib/resolver.mli
+++ b/lib/resolver.mli
@@ -25,7 +25,7 @@ type service = {
   name: string;
   port: int;
   tls: bool
-} with sexp
+} [@@deriving sexp]
 
 (** Module type for a {{!resolution}resolver} that can map URIs to
     concrete {{!endp}endpoints} that stream connections can be
@@ -37,11 +37,11 @@ module type S = sig
   type +'a io
 
   (** State handle for a running resolver *)
-  type t with sexp
+  type t [@@deriving sexp]
 
   (** Abstract type for a service entry, which maps a URI scheme into
       a protocol handler and TCP port *)
-  type svc with sexp
+  type svc [@@deriving sexp]
 
   (** A rewrite function resolves a {{!svc}service} and a URI into
       a concrete endpoint. *)

--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -2,8 +2,6 @@ open Ocamlbuild_plugin ;;
 dispatch (
   function
   | After_rules ->
-    pflag ["ocaml";"compile";] "define" (fun s -> S [A"-ppopt"; A ("-D"^s)]);
-    pflag ["ocaml";"ocamldep";] "define" (fun s -> S [A"-ppopt"; A ("-D"^s)]);
     dep ["ocaml"; "doc"] ["lib/intro.html"];
     flag ["ocaml"; "doc"] (S[A"-hide-warnings"; A"-short-functors"; A"-sort"; A"-m"; A"A"; A"-intro"; A"lib/intro.html"; A"-t"; A"Conduit URI resolution"]);
   | _ -> ()

--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -2,6 +2,7 @@ open Ocamlbuild_plugin ;;
 dispatch (
   function
   | After_rules ->
+    dep ["ocaml"; "config"] ["lib/conduit_config.mlh"];
     dep ["ocaml"; "doc"] ["lib/intro.html"];
     flag ["ocaml"; "doc"] (S[A"-hide-warnings"; A"-short-functors"; A"-sort"; A"-m"; A"A"; A"-intro"; A"lib/intro.html"; A"-t"; A"Conduit URI resolution"]);
   | _ -> ()

--- a/opam
+++ b/opam
@@ -14,8 +14,10 @@ remove:  ["ocamlfind" "remove" "conduit"]
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "pa_sexp_conv"
-  "type_conv"
+  "ppx_driver" {build}
+  "ppx_optcomp" {build}
+  "ppx_sexp_conv" {build}
+  "sexplib"
   "stringext"
   "uri"
   "cstruct" {>="1.0.1"}
@@ -42,4 +44,4 @@ conflicts: [
   "vchan" {<"2.0.0"}
   "nocrypto" {<"0.4.0"}
 ]
-available: [ocaml-version >= "4.02.0"]
+available: [ocaml-version >= "4.01.0"]

--- a/opam
+++ b/opam
@@ -44,4 +44,4 @@ conflicts: [
   "vchan" {<"2.0.0"}
   "nocrypto" {<"0.4.0"}
 ]
-available: [ocaml-version >= "4.01.0"]
+available: [ocaml-version >= "4.02.3"]


### PR DESCRIPTION
First commit explains why we must use ppx_driver over ppx_deriving for now.

The only thing that remains to be done here is to somehow tell ocamlbuild that
conduit_config.mlh is a dependency for every file that is being preprocessed.

Any ocamlbuild gurus can help out with this?

~~gasche samoht Drup dbuenzli agarwal~~ (removed the mentions)

Also, we need to wait for TLS to switch over to ppx as well.