### PR TITLE
Use pa_sexp_conv and bump to 0.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ script: bash ./.travis-docker.sh
 env:
  global:
    - PACKAGE="conduit"
-   - DEPOPTS="async_ssl lwt mirage-dns ssl tls"
+   - DEPOPTS="async_ssl lwt mirage-dns ssl"
  matrix:
    - DISTRO=debian-stable OCAML_VERSION=4.02.3
    - DISTRO=debian-testing OCAML_VERSION=4.02.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,15 @@ script: bash ./.travis-docker.sh
 env:
  global:
    - PACKAGE="conduit"
+   - DEPOPTS="async_ssl lwt mirage-dns ssl tls"
  matrix:
-   - DISTRO=debian-stable OCAML_VERSION=4.02.3 DEPOPTS="lwt"
-   - DISTRO=debian-testing OCAML_VERSION=4.02.3 DEPOPTS="lwt ssl tls"
-   - DISTRO=debian-unstable OCAML_VERSION=4.02.3 DEPOPTS="async_ssl.113.00.01"
-   - DISTRO=ubuntu-12.04 OCAML_VERSION=4.01.0 DEPOPTS="lwt ssl async"
-   - DISTRO=ubuntu-15.10 OCAML_VERSION=4.02.3 DEPOPTS="lwt async_ssl.113.00.01"
-   - DISTRO=ubuntu-16.04 OCAML_VERSION=4.02.3 DEPOPTS="lwt async_ssl.113.00.01"
-   - DISTRO=centos-6 OCAML_VERSION=4.01.0 DEPOPTS="lwt ssl async"
-   - DISTRO=centos-7 OCAML_VERSION=4.02.3 DEPOPTS="lwt async_ssl.113.00.01"
-   - DISTRO=fedora-23 OCAML_VERSION=4.02.3 DEPOPTS="lwt async_ssl.113.00.01"
-   - DISTRO=alpine-3.3 OCAML_VERSION=4.02.3 DEPOPTS="lwt"
+   - DISTRO=debian-stable OCAML_VERSION=4.02.3
+   - DISTRO=debian-testing OCAML_VERSION=4.02.3
+   - DISTRO=debian-unstable OCAML_VERSION=4.02.3
+   - DISTRO=ubuntu-12.04 OCAML_VERSION=4.02.3
+   - DISTRO=ubuntu-15.10 OCAML_VERSION=4.02.3
+   - DISTRO=ubuntu-16.04 OCAML_VERSION=4.02.3
+   - DISTRO=centos-6 OCAML_VERSION=4.02.3
+   - DISTRO=centos-7 OCAML_VERSION=4.02.3
+   - DISTRO=fedora-23 OCAML_VERSION=4.02.3
+   - DISTRO=alpine-3.3 OCAML_VERSION=4.02.3

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,7 @@
 * Add multi-distro Travis testing script.
 * Switch to using `pa_sexp_conv` for latest sexp.
+* Fix `vchan` example code, and use functoria-style mirage
+  for it (#108 via @jonludlam)
 
 0.10.0 (2015-12-25):
 * Add support for CA certificates in [Conduit_async.serve] (#98).

--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,8 @@
 * Support Core/Async >=113.24
 * Fix `vchan` example code, and use functoria-style mirage
   for it (#108 via @jonludlam)
+* [async] Add an `Ssl_unsupported exception` for Async rather than
+  just raising `Failure`
 
 0.10.0 (2015-12-25):
 * Add support for CA certificates in [Conduit_async.serve] (#98).

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,8 @@
+0.11.0 (trunk):
+* Minimum OCaml version is now 4.02.3
 * Add multi-distro Travis testing script.
 * Switch to using `pa_sexp_conv` for latest sexp.
+* Support Core/Async >=113.24
 * Fix `vchan` example code, and use functoria-style mirage
   for it (#108 via @jonludlam)
 

--- a/build.sh
+++ b/build.sh
@@ -4,13 +4,13 @@ TAGS=principal,annot,bin_annot,short_paths,thread,strict_sequence
 J_FLAG=2
 
 BASE_PKG="sexplib ipaddr cstruct uri stringext"
-SYNTAX_PKG="camlp4.macro sexplib.syntax"
+SYNTAX_PKG="camlp4.macro pa_sexp_conv"
 
 # The Async backend is only supported in OCaml 4.01.0+
 OCAML_VERSION=`ocamlc -version`
 case $OCAML_VERSION in
-4.00.*|3.*)
-  echo Async backend only supported in OCaml 4.01.0 or higher
+4.01.*|4.00.*|3.*)
+  echo Minimum OCaml version is 4.02
   ;;
 *)
 HAVE_ASYNC=`ocamlfind query async 2>/dev/null || true`

--- a/lib/conduit_async.ml
+++ b/lib/conduit_async.ml
@@ -122,7 +122,7 @@ type server = [
 ] with sexp
 
 let serve
-      ?max_connections ?max_pending_connections
+      ?max_connections
       ?buffer_age_limit ?on_handler_error mode where_to_listen handle_request =
   let handle_client handle_request sock rd wr =
     match mode with
@@ -150,6 +150,6 @@ ELSE
         raise Ssl_unsupported
 END
     in
-    Tcp.Server.create ?max_connections ?max_pending_connections
+    Tcp.Server.create ?max_connections
       ?buffer_age_limit ?on_handler_error
       where_to_listen (handle_client handle_request)

--- a/lib/conduit_async.mli
+++ b/lib/conduit_async.mli
@@ -97,7 +97,6 @@ type server = [
 
 val serve :
   ?max_connections:int ->
-  ?max_pending_connections:int ->
   ?buffer_age_limit:Writer.buffer_age_limit ->
   ?on_handler_error:[ `Call of ([< Socket.Address.t ] as 'a) -> exn -> unit
     | `Ignore

--- a/opam
+++ b/opam
@@ -42,4 +42,4 @@ conflicts: [
   "vchan" {<"2.0.0"}
   "nocrypto" {<"0.4.0"}
 ]
-available: [ocaml-version >= "4.01.0"]
+available: [ocaml-version >= "4.02.0"]

--- a/opam
+++ b/opam
@@ -14,7 +14,7 @@ remove:  ["ocamlfind" "remove" "conduit"]
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "sexplib" {>="109.15.00" & <"113.24.00"}
+  "pa_sexp_conv"
   "type_conv"
   "stringext"
   "uri"
@@ -35,7 +35,6 @@ depopts: [
 conflicts: [
   "lwt" {<"2.4.4"}
   "async_ssl" {<"112.24.00"}
-  "async" {>"113.24.00"}
   "mirage-types" {<"2.0.0"}
   "dns" {<"0.10.0"}
   "tls" {<"0.4.0"}

--- a/opam
+++ b/opam
@@ -35,6 +35,7 @@ depopts: [
 conflicts: [
   "lwt" {<"2.4.4"}
   "async_ssl" {<"112.24.00"}
+  "async" {<"113.24.00"}
   "mirage-types" {<"2.0.0"}
   "dns" {<"0.10.0"}
   "tls" {<"0.4.0"}


### PR DESCRIPTION
This lets us leap the Core >=113.24 constraint without a full switch to ppx (which requires some dependent changes in #122 