### PR TITLE
Move conduit/lwt server code to shared module

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -82,7 +82,8 @@ if [ "$HAVE_LWT" != "" ]; then
   LWT_REQUIRES="lwt"
   LWT_UNIX_REQUIRES="lwt.unix ipaddr.unix uri.services"
 
-  echo Conduit_lwt_unix > lib/conduit-lwt-unix.mllib
+  echo Conduit_lwt_server > lib/conduit-lwt-unix.mllib
+  echo Conduit_lwt_unix >> lib/conduit-lwt-unix.mllib
   echo Resolver_lwt_unix >> lib/conduit-lwt-unix.mllib
   add_target "conduit-lwt-unix"
 

--- a/lib/conduit_lwt_server.ml
+++ b/lib/conduit_lwt_server.ml
@@ -1,0 +1,28 @@
+open Lwt.Infix
+
+let safe_close t =
+  Lwt.catch
+    (fun () -> Lwt_io.close t)
+    (fun _ -> Lwt.return_unit)
+
+let close (ic, oc) =
+  safe_close oc >>= fun () ->
+  safe_close ic
+
+let with_socket sockaddr f =
+  let fd =
+    Lwt_unix.socket (Unix.domain_of_sockaddr sockaddr) Unix.SOCK_STREAM 0 in
+  Lwt.catch (fun () -> f fd) (fun e ->
+      Lwt.catch
+        (fun () -> Lwt_unix.close fd)
+        (fun _ -> Lwt.return_unit)
+      >>= fun () ->
+      Lwt.fail e)
+
+let process_accept ~timeout callback (sa,ic,oc) =
+  let c = callback sa ic oc in
+  let events = match timeout with
+    | None -> [c]
+    | Some t -> [c; (Lwt_unix.sleep (float_of_int t)) ] in
+  Lwt.finalize (fun () ->  Lwt.pick events) (fun () -> close (ic,oc))
+  |> Lwt.ignore_result

--- a/lib/conduit_lwt_server.mli
+++ b/lib/conduit_lwt_server.mli
@@ -1,0 +1,13 @@
+
+val close : 'a Lwt_io.channel * 'b Lwt_io.channel -> unit Lwt.t
+
+val with_socket
+  : Unix.sockaddr
+  -> (Lwt_unix.file_descr -> 'a Lwt.t)
+  -> 'a Lwt.t
+
+val process_accept
+  : timeout:int option
+  -> ('a -> 'b Lwt_io.channel -> 'c Lwt_io.channel -> unit Lwt.t)
+  -> 'a * 'b Lwt_io.channel * 'c Lwt_io.channel
+  -> unit

--- a/lib/conduit_lwt_unix_ssl.mli
+++ b/lib/conduit_lwt_unix_ssl.mli
@@ -53,6 +53,6 @@ module Server : sig
     unit Lwt.t
 end
 
-val close :
-  Lwt_io.input_channel * Lwt_io.output_channel ->
-  unit Lwt.t
+val close
+  : Lwt_io.input_channel * Lwt_io.output_channel
+  -> unit Lwt.t


### PR DESCRIPTION
The various lwt server backends all have the same set of functions that are
copied around everywhere. Move these functions to a Conduit_lwt_server module.