### PR TITLE
 Handle failed lwt threads in server

### DIFF
--- a/lib/conduit_lwt_unix.ml
+++ b/lib/conduit_lwt_unix.ml
@@ -346,6 +346,10 @@ let serve_with_default_tls ?timeout ?stop ~ctx ~certfile ~keyfile
 
 let serve ?timeout ?stop ~(ctx:ctx) ~(mode:server) callback =
   let t, _u = Lwt.task () in (* End this via Lwt.cancel *)
+  let callback flow ic oc = Lwt.catch
+    (fun () -> callback flow ic oc)
+    (fun exn -> !Lwt.async_exception_hook exn; Lwt.return_unit)
+  in
   match mode with
   | `TCP (`Port port) ->
        let sockaddr, ip = sockaddr_on_tcp_port ctx port in

--- a/lib/conduit_lwt_unix.ml
+++ b/lib/conduit_lwt_unix.ml
@@ -346,7 +346,6 @@ let serve_with_default_tls ?timeout ?stop ~ctx ~certfile ~keyfile
 
 let serve ?timeout ?stop ~(ctx:ctx) ~(mode:server) callback =
   let t, _u = Lwt.task () in (* End this via Lwt.cancel *)
-  Lwt.on_cancel t (fun () -> print_endline "Terminating server thread");
   match mode with
   | `TCP (`Port port) ->
        let sockaddr, ip = sockaddr_on_tcp_port ctx port in

--- a/lib/conduit_lwt_unix.mli
+++ b/lib/conduit_lwt_unix.mli
@@ -163,7 +163,8 @@ val connect : ctx:ctx -> client -> (flow * ic * oc) io
     lightweight thread that is invoked via the [fn] callback.
     The [fn] callback is passed the {!flow} representing the
     client connection and the associated input {!ic} and output
-    {!oc} channels. *)
+    {!oc} channels. If the callback raises an exception, it is
+    passed to [!Lwt.async_exception_hook]. *)
 val serve :
   ?timeout:int -> ?stop:(unit io) -> ctx:ctx ->
    mode:server -> (flow -> ic -> oc -> unit io) -> unit io

--- a/lib/conduit_mirage.ml
+++ b/lib/conduit_mirage.ml
@@ -195,7 +195,6 @@ module TCP (S: V1_LWT.STACKV4) = struct
 
   let listen t (`TCP port: server) fn =
     let s, _u = Lwt.task () in
-    Lwt.on_cancel s (fun () -> print_endline "Stopping server thread");
     S.listen_tcpv4 t ~port (fun flow ->
         let f = Flow.create (module S.TCPV4) flow in
         fn f


### PR DESCRIPTION
This is a fix for #141. It follows the strategy of `Lwt_io.establish_server_safe`, which passes exceptions from the callback to `Lwt.async_exception_hook` (which by default prints the exception and terminates the program).