### PR TITLE
Allow TCP ctx from existing file_descriptors

### DIFF
--- a/lib/conduit_lwt_unix.ml
+++ b/lib/conduit_lwt_unix.ml
@@ -82,12 +82,18 @@ type server_tls_config =
   [ `Port of int ]
 [@@deriving sexp]
 
+(** Set of ways to create TCP servers *)
+type tcp_config = [
+  | `Port of int
+  | `Socket of Lwt_unix.file_descr sexp_opaque
+] [@@deriving sexp]
+
 (** Set of supported listening mechanisms that are supported by this module. *)
 type server = [
   | `TLS of server_tls_config
   | `OpenSSL of server_tls_config
   | `TLS_native of server_tls_config
-  | `TCP of [ `Port of int ]
+  | `TCP of tcp_config
   | `Unix_domain_socket of [ `File of string ]
   | `Vchan_direct of int * string
   | `Vchan_domain_socket of string  * string
@@ -331,6 +337,8 @@ let serve ?backlog ?timeout ?stop
   | `TCP (`Port port) ->
     let sockaddr, ip = sockaddr_on_tcp_port ctx port in
     Sockaddr_server.init ~on:(`Sockaddr sockaddr) ?backlog ?timeout ?stop callback
+  | `TCP (`Socket s) ->
+    Sockaddr_server.init ~on:(`Socket s) ?timeout ?stop callback
   | `Unix_domain_socket (`File path) ->
     let sockaddr = Unix.ADDR_UNIX path in
     Sockaddr_server.init ~on:(`Sockaddr sockaddr) ?backlog ?timeout ?stop callback

--- a/lib/conduit_lwt_unix.mli
+++ b/lib/conduit_lwt_unix.mli
@@ -71,6 +71,15 @@ type server_tls_config =
   [ `Port of int ]
 [@@deriving sexp]
 
+(** Set of ways to create TCP servers
+   - [`Port port]: Create a socket listening to provided port.
+   - [`Socket file_descr]: Use the provided file descriptor to create a server.
+*)
+type tcp_config = [
+  | `Port of int
+  | `Socket of Lwt_unix.file_descr sexp_opaque
+] [@@deriving sexp]
+
 (** Set of supported listening mechanisms that are supported by this module. 
    - [`TLS server_tls_config]: Use OCaml-TLS or OpenSSL (depending on CONDUIT_TLS) to connect
      to the given [host], [ip], [port] tuple via TCP.
@@ -88,7 +97,7 @@ type server = [
   | `TLS of server_tls_config
   | `OpenSSL of server_tls_config
   | `TLS_native of server_tls_config
-  | `TCP of [ `Port of int ]
+  | `TCP of tcp_config
   | `Unix_domain_socket of [ `File of string ]
   | `Vchan_direct of int * string
   | `Vchan_domain_socket of string  * string


### PR DESCRIPTION
This PR opens up the possibility of tracking and manipulating server file descriptors from the application code. I've implemented it for my own needs and I hope others will also find it useful.
