### PR TITLE
Increase listen backlog, and make it optional param

### DIFF
--- a/lib/conduit_lwt_unix.mli
+++ b/lib/conduit_lwt_unix.mli
@@ -156,9 +156,9 @@ val init : ?src:string -> ?tls_server_key:tls_server_key -> unit -> ctx io
     via the [ctx] context to the endpoint described by [client] *)
 val connect : ctx:ctx -> client -> (flow * ic * oc) io
 
-(** [serve ?timeout ?stop ~ctx ~mode fn] establishes a listening
-    connection of type [mode], using the [ctx] context.  The
-    [stop] thread will terminate the server if it ever becomes
+(** [serve ?backlog ?timeout ?stop ~ctx ~mode fn] establishes a
+    listening connection of type [mode], using the [ctx] context.
+    The [stop] thread will terminate the server if it ever becomes
     determined.  Every connection will be served in a new
     lightweight thread that is invoked via the [fn] callback.
     The [fn] callback is passed the {!flow} representing the
@@ -166,7 +166,7 @@ val connect : ctx:ctx -> client -> (flow * ic * oc) io
     {!oc} channels. If the callback raises an exception, it is
     passed to [!Lwt.async_exception_hook]. *)
 val serve :
-  ?timeout:int -> ?stop:(unit io) -> ctx:ctx ->
+  ?backlog:int -> ?timeout:int -> ?stop:(unit io) -> ctx:ctx ->
    mode:server -> (flow -> ic -> oc -> unit io) -> unit io
 
 (** [endp_of_flow flow] retrieves the original {!Conduit.endp}


### PR DESCRIPTION
This is my first OCaml contribution, I am a bit excited about it and I might need your help ^_^

A little backstory, I am using cohttp in a small personal project, and at some point I wanted to do some micro benchmarking. I used siege and for comparison, I've chosen Python's tornado library. In general it is a lot faster than tornado & Python. But there's one thing, when I increased the number of concurrent users above 15 (used siege's --concurrent parameter), I've got too many "connection reset by peer" errors. Tornado were still fine with numbers above 15. By following cohttp lwt code path, I've found that backlog parameter for listen call is hardcoded in conduit, and it is 15! So this was the answer, and I increased that number to 128 - I used opam pin, which is awesome. After this change, cohttp started to beat tornado in this case, as well ^_^

So in this PR, I added backlog optional parameter (to conduit_lwt_unix), and set its default value to 128. This change also matches with conduit_async, since it has optional backlog parameter already. To back that number up, some reference from other projects:

Tornado sets it to 128:

https://github.com/tornadoweb/tornado/blob/e66728af9f8957cf868b8b520438964dccb8644b/tornado/netutil.py#L108

which is also the default maximum on linux:

https://github.com/torvalds/linux/blob/b22734a55067adbc10216e459762dbd7dcef29d5/include/linux/socket.h#L257
https://github.com/torvalds/linux/blob/b22734a55067adbc10216e459762dbd7dcef29d5/include/linux/tcp.h#L409

Redis and Nginx set it to 511 (default maximum is 128, so if someone need this to be effective, they need to increase net.core.somaxxconn, too):

https://github.com/antirez/redis/blob/e9d861ec69a11208578fc2a8b7dcdf4c52df316e/src/server.h#L83
https://trac.nginx.org/nginx/browser/nginx/src/os/unix/ngx_linux_config.h?rev=29bf0dbc0a77914bc94bd001a2b17d364e8e50d9#L102