### PR TITLE
try returning an lwt thread that also runs Stack.listen

### DIFF
--- a/lib/conduit_mirage.ml
+++ b/lib/conduit_mirage.ml
@@ -199,7 +199,8 @@ module TCP (S: V1_LWT.STACKV4) = struct
         let f = Flow.create (module S.TCPV4) flow in
         fn f
       );
-    s
+    let stack_listener = S.listen t in
+    Lwt.pick [stack_listener; s]
 
 end
 


### PR DESCRIPTION
`tcpip_stack_direct.ml` no longer starts a listening thread automatically with `let _ = S.listen` on connect.  Libraries which wrap the stack need to be sure to call `listen` to allow the stack to hear incoming traffic (even if no TCP or UDP listeners are registered -- replies to outgoing connection requests still need to be heard, and the stack will still need to hear lower-level packets to communicate on the network at all).