### PR TITLE
depend on mirage-runtime; simplify as FLOW now returns result types

### DIFF
--- a/discover.ml
+++ b/discover.ml
@@ -175,7 +175,7 @@ module Libs = struct
 
   let mirage =
     { name = "conduit-lwt-mirage"
-    ; findlib = ["uri.services"]
+    ; findlib = ["uri.services"; "mirage-runtime"]
     ; always_modules = ["Conduit_mirage" ; "Resolver_mirage"]
     ; need_flags = [mirage]
     ; flag_modules = ["Conduit_xenstore", vchan]

--- a/lib/resolver_mirage.ml
+++ b/lib/resolver_mirage.ml
@@ -110,8 +110,9 @@ module Make(DNS:Dns_resolver_mirage.S) = struct
       : Conduit.endp Lwt.t =
     let host = get_host uri in
     let port = get_port service uri in
-    DNS.gethostbyname ~server:ns ~dns_port:ns_port dns host
-    >>= fun res ->
+    (match Ipaddr.of_string host with
+    | None -> DNS.gethostbyname ~server:ns ~dns_port:ns_port dns host
+    | Some addr -> return [addr]) >>= fun res ->
     List.filter (function Ipaddr.V4 _ -> true | _ -> false) res
     |> function
     | [] -> return (`Unknown ("name resolution failed"))

--- a/mirage-conduit.opam
+++ b/mirage-conduit.opam
@@ -12,6 +12,7 @@ depends: [
   "mirage-types-lwt" {>= "2.3.0"}
   "mirage-dns" {>= "2.0.0"}
   "conduit"    {>= "0.8.4"}
+  "mirage-runtime"
 ]
 depopts: [
   "vchan"

--- a/opam
+++ b/opam
@@ -33,6 +33,7 @@ depopts: [
   "vchan"
   "launchd"
   "tls"
+  "mirage-runtime"
   "mirage-types-lwt"
 ]
 conflicts: [


### PR DESCRIPTION
See mirage/mirage#690 for details on the MirageOS 3 pull request this changeset supports.