### PR TITLE
Use Logs to report Conduit_lwt_unix_ssl exceptions

### DIFF
--- a/discover.ml
+++ b/discover.ml
@@ -138,7 +138,7 @@ let vchan       = Flag.mk "vchan" ["vchan"]
 let vchan_lwt   = Flag.mk "vchan_lwt" ["vchan.lwt"]
 let launchd_lwt = Flag.mk "launchd_lwt" ["launchd.lwt"]
 
-let base_findlib = ["sexplib" ; "ipaddr" ; "cstruct" ; "uri" ; "stringext"]
+let base_findlib = ["sexplib" ; "ipaddr" ; "cstruct" ; "uri" ; "stringext"; "logs"]
 
 module Libs = struct
   open Pkg

--- a/opam
+++ b/opam
@@ -21,6 +21,7 @@ depends: [
   "sexplib"
   "stringext"
   "uri"
+  "logs" {>="0.5.0"}
   "cstruct" {>="1.0.1"}
   "ipaddr" {>="2.5.0"}
 ]


### PR DESCRIPTION
Before, we silently discarded errors here.

I only added logging to `Conduit_lwt_unix_ssl` for now because I'm trying to debug a problem there at the moment (after a week or so, attempting to connection to my server just hangs, although the process is still working fine apart from that). If people are happy with the extra dependency, I could add logging elsewhere too.