### PR TITLE
serve: change error mgmt

### DIFF
--- a/lib/conduit_lwt_unix.mli
+++ b/lib/conduit_lwt_unix.mli
@@ -156,18 +156,19 @@ val init : ?src:string -> ?tls_server_key:tls_server_key -> unit -> ctx io
     via the [ctx] context to the endpoint described by [client] *)
 val connect : ctx:ctx -> client -> (flow * ic * oc) io
 
-(** [serve ?backlog ?timeout ?stop ~ctx ~mode fn] establishes a
-    listening connection of type [mode], using the [ctx] context.
-    The [stop] thread will terminate the server if it ever becomes
-    determined.  Every connection will be served in a new
-    lightweight thread that is invoked via the [fn] callback.
-    The [fn] callback is passed the {!flow} representing the
-    client connection and the associated input {!ic} and output
-    {!oc} channels. If the callback raises an exception, it is
-    passed to [!Lwt.async_exception_hook]. *)
+(** [serve ?backlog ?timeout ?stop ?on_exn ~ctx ~mode fn]
+    establishes a listening connection of type [mode], using the [ctx]
+    context.  The [stop] thread will terminate the server if it ever
+    becomes determined.  Every connection will be served in a new
+    lightweight thread that is invoked via the [fn] callback.  The
+    [fn] callback is passed the {!flow} representing the client
+    connection and the associated input {!ic} and output {!oc}
+    channels. If the callback raises an exception, it is passed to
+    [on_exn] (by default, to !Lwt.async_exception_hook). *)
 val serve :
-  ?backlog:int -> ?timeout:int -> ?stop:(unit io) -> ctx:ctx ->
-   mode:server -> (flow -> ic -> oc -> unit io) -> unit io
+  ?backlog:int -> ?timeout:int -> ?stop:(unit io) ->
+  ?on_exn:(exn -> unit) -> ctx:ctx -> mode:server ->
+  (flow -> ic -> oc -> unit io) -> unit io
 
 (** [endp_of_flow flow] retrieves the original {!Conduit.endp}
     from the established [flow] *)


### PR DESCRIPTION
For Tezos, we need a way that server exception are not sent to `async_exception_hook`, because we want to filter them otherwise we could not differentiate them from similar exceptions coming from another part of the program.