### PR TITLE
Remove all deprecated functions

### DIFF
--- a/lib/conduit_lwt_tls.ml
+++ b/lib/conduit_lwt_tls.ml
@@ -37,8 +37,6 @@ module Client = struct
 end
 
 module Server = struct
-  let listen backlog sa = Conduit_lwt_server.listen ~backlog sa
-
   let accept config s =
     Lwt_unix.accept s >>= fun (fd, _) ->
     Lwt.try_bind (fun () ->

--- a/lib/conduit_lwt_tls.mli
+++ b/lib/conduit_lwt_tls.mli
@@ -28,24 +28,18 @@ module Client : sig
 end
 
 module Server : sig
-  val accept :
-    Tls.Config.server ->
-    Lwt_unix.file_descr ->
-    (Lwt_unix.file_descr * Lwt_io.input_channel * Lwt_io.output_channel) Lwt.t
-  [@@@deprecated "Low level function. Will be removed."]
-
-  val listen : int -> Lwt_unix.sockaddr -> Lwt_unix.file_descr
-  [@@@deprecated "Low level function. Will be removed."]
-
-  val init :
-    ?backlog:int ->
-    certfile:string ->
-    keyfile:string ->
-    ?stop:(unit Lwt.t) ->
-    ?timeout:int ->
-    Lwt_unix.sockaddr ->
-    (Lwt_unix.file_descr -> Lwt_io.input_channel -> Lwt_io.output_channel -> unit Lwt.t) ->
-    unit Lwt.t
+  val init
+    : ?backlog:int
+    -> certfile:string
+    -> keyfile:string
+    -> ?stop:(unit Lwt.t)
+    -> ?timeout:int
+    -> Lwt_unix.sockaddr
+    -> (Lwt_unix.file_descr
+        -> Lwt_io.input_channel
+        -> Lwt_io.output_channel
+        -> unit Lwt.t)
+    -> unit Lwt.t
 
   val init'
     : ?backlog:int

--- a/lib/conduit_lwt_unix_ssl.ml
+++ b/lib/conduit_lwt_unix_ssl.ml
@@ -49,12 +49,6 @@ module Server = struct
   let default_ctx = Ssl.create_context Ssl.SSLv23 Ssl.Server_context
   let () = Ssl.disable_protocols default_ctx [Ssl.SSLv23]
 
-  let accept ?(ctx=default_ctx) fd =
-    Lwt_unix.accept fd >>= fun (afd, _) ->
-    Lwt.try_bind (fun () -> Lwt_ssl.ssl_accept afd ctx)
-      (fun sock -> Lwt.return (chans_of_fd sock))
-      (fun exn -> Lwt_unix.close afd >>= fun () -> Lwt.fail exn)
-
   let listen ?(ctx=default_ctx) ?backlog ?password ~certfile ~keyfile sa =
     let fd = Conduit_lwt_server.listen ?backlog sa in
     (match password with
@@ -63,7 +57,8 @@ module Server = struct
     Ssl.use_certificate ctx certfile keyfile;
     fd
 
-  let init ?(ctx=default_ctx) ?backlog ?password ~certfile ~keyfile ?stop ?timeout sa cb =
+  let init ?(ctx=default_ctx) ?backlog ?password ~certfile ~keyfile ?stop
+      ?timeout sa cb =
     sa
     |> listen ~ctx ?backlog ?password ~certfile ~keyfile
     |> Conduit_lwt_server.init ?stop (fun (fd, _) ->
@@ -74,6 +69,3 @@ module Server = struct
         |> Lwt.ignore_result)
 
 end
-
-(* Should this be deprecated? Not really ssl related in any way *)
-let close = Conduit_lwt_server.close

--- a/lib/conduit_lwt_unix_ssl.mli
+++ b/lib/conduit_lwt_unix_ssl.mli
@@ -31,34 +31,18 @@ end
 module Server : sig
   val default_ctx : Ssl.context
 
-  val accept :
-    ?ctx:Ssl.context ->
-    Lwt_unix.file_descr ->
-    (Lwt_unix.file_descr * Lwt_io.input_channel * Lwt_io.output_channel) Lwt.t
-  [@@@deprecated "Low level function. Will be removed."]
-
-  val listen :
-    ?ctx:Ssl.context ->
-    ?backlog:int ->
-    ?password:(bool -> string) ->
-    certfile:string ->
-    keyfile:string -> Lwt_unix.sockaddr -> Lwt_unix.file_descr
-  [@@@deprecated "Low level function. Will be removed."]
-
-  val init :
-    ?ctx:Ssl.context ->
-    ?backlog:int ->
-    ?password:(bool -> string) ->
-    certfile:string ->
-    keyfile:string ->
-    ?stop:(unit Lwt.t) ->
-    ?timeout:int ->
-    Lwt_unix.sockaddr ->
-    (Lwt_unix.file_descr -> Lwt_io.input_channel -> Lwt_io.output_channel -> unit Lwt.t) ->
-    unit Lwt.t
+  val init
+    : ?ctx:Ssl.context
+    -> ?backlog:int
+    -> ?password:(bool -> string)
+    -> certfile:string
+    -> keyfile:string
+    -> ?stop:(unit Lwt.t)
+    -> ?timeout:int
+    -> Lwt_unix.sockaddr
+    -> (Lwt_unix.file_descr
+        -> Lwt_io.input_channel
+        -> Lwt_io.output_channel
+        -> unit Lwt.t)
+    -> unit Lwt.t
 end
-
-val close
-  : Lwt_io.input_channel * Lwt_io.output_channel
-  -> unit Lwt.t
-[@@@deprecated "Low level function. Will be removed."]


### PR DESCRIPTION
I've done some snooping around of our reverse dependencies and it seems like we
can just get rid of all this stuff without any breakage.