### PR TITLE
Tests: do not link with lwt.ssl if it is not installed

### DIFF
--- a/discover.ml
+++ b/discover.ml
@@ -230,7 +230,7 @@ let tags =
   ; "<lib>: include"
   ; "<tests/*>: include"
   ; "<tests/**>: package(lwt.unix), package(tls.lwt), package(ipaddr.unix)"
-  ; "<tests/unix/**>: package(lwt.ssl)"
+  ; if Flag.has_flag lwt_ssl then "<tests/unix/**>: package(lwt.ssl)" else ""
   ; "<tests/mirage/**>: package(vchan.lwt)"
   ] @ extra_tags
 


### PR DESCRIPTION
cdtest.ml uses lwt.ssl, and the Makefile won't build it if lwt.ssl is
not available.
cdtest_tls works fine with just tls.lwt, but if conduit got built with
lwt.ssl, then lwt.ssl is needed during linking, otherwise it is not.

Fixes https://github.com/ocaml/opam-repository/issues/8166

All the travis tests have `ssl` as depopts installed, I wonder if its possible to have at least one Travis build which has only `tls.lwt'` installed but not `ssl`.