### PR TITLE
refer to mirage module types modules by new name

### DIFF
--- a/lib/conduit_mirage.mli
+++ b/lib/conduit_mirage.mli
@@ -21,7 +21,7 @@
   *)
 #import "conduit_config.mlh"
 
-module Flow: V1_LWT.FLOW
+module Flow: Mirage_types_lwt.FLOW
 (** Dynamic flows. *)
 
 type callback = Flow.flow -> unit Lwt.t
@@ -55,7 +55,7 @@ type tcp_client = [ `TCP of Ipaddr.t * int ] (** address and destination port *)
 and tcp_server  = [ `TCP of int ]                          (** listening port *)
 
 type 'a stackv4
-val stackv4: (module V1_LWT.STACKV4 with type t = 'a) -> 'a stackv4
+val stackv4: (module Mirage_types_lwt.STACKV4 with type t = 'a) -> 'a stackv4
 
 (** {1 VCHAN} *)
 
@@ -125,7 +125,7 @@ module type S = sig
   val empty: t
   (** The empty conduit. *)
 
-  module With_tcp (S:V1_LWT.STACKV4) : sig
+  module With_tcp (S:Mirage_types_lwt.STACKV4) : sig
     val connect : S.t -> t -> t Lwt.t
   end
 
@@ -148,7 +148,7 @@ end
 
 include S
 
-module Context (T: V1_LWT.TIME) (S: V1_LWT.STACKV4): sig
+module Context (T: Mirage_types_lwt.TIME) (S: Mirage_types_lwt.STACKV4): sig
 
   (** {1 Context for MirageOS conduit resolvers} *)
 

--- a/lib/resolver_mirage.ml
+++ b/lib/resolver_mirage.ml
@@ -139,7 +139,7 @@ module Make(DNS:Dns_resolver_mirage.S) = struct
     res
 end
 
-module Make_with_stack (T: V1_LWT.TIME) (S: V1_LWT.STACKV4) = struct
+module Make_with_stack (T: Mirage_types_lwt.TIME) (S: Mirage_types_lwt.STACKV4) = struct
   module R = Make(Dns_resolver_mirage.Make(T)(S))
   include Resolver_lwt
 end

--- a/lib/resolver_mirage.mli
+++ b/lib/resolver_mirage.mli
@@ -59,7 +59,7 @@ module Make(DNS:Dns_resolver_mirage.S) : S with module DNS = DNS
 (** Provides a DNS-enabled {!Resolver_lwt} given a network stack.
     See {!Make}.
 *)
-module Make_with_stack (T: V1_LWT.TIME) (S: V1_LWT.STACKV4) : sig
+module Make_with_stack (T: Mirage_types_lwt.TIME) (S: Mirage_types_lwt.STACKV4) : sig
   include Resolver_lwt.S with type t = Resolver_lwt.t
   module R : S with type DNS.stack = S.t
 end

--- a/tests/mirage/http-fetch/unikernel.ml
+++ b/tests/mirage/http-fetch/unikernel.ml
@@ -1,5 +1,5 @@
 open Lwt.Infix
-open V1_LWT
+open Mirage_types_lwt
 open Printf
 
 let red fmt    = sprintf ("\027[31m"^^fmt^^"\027[m")

--- a/tests/mirage/http-server/unikernel.ml
+++ b/tests/mirage/http-server/unikernel.ml
@@ -1,5 +1,5 @@
 open Lwt.Infix
-open V1_LWT
+open Mirage_types_lwt
 open Printf
 
 let red fmt    = sprintf ("\027[31m"^^fmt^^"\027[m")

--- a/tests/mirage/vchan/unikernel.ml
+++ b/tests/mirage/vchan/unikernel.ml
@@ -5,7 +5,7 @@ let conduit = Conduit_mirage.empty
 let vchan = Conduit_mirage.vchan (module Vchan_xen)
 let xs = Conduit_mirage.xs (module OS.Xs)
 
-module Server(Time : V1_LWT.TIME) = struct
+module Server(Time : Mirage_types_lwt.TIME) = struct
 
   let server_src = Logs.Src.create "server" ~doc:"vchan server"
   module Log = (val Logs.src_log server_src : Logs.LOG)
@@ -32,7 +32,7 @@ module Server(Time : V1_LWT.TIME) = struct
 
 end
 
-module Client (Time : V1_LWT.TIME) = struct
+module Client (Time : Mirage_types_lwt.TIME) = struct
 
   let client_src = Logs.Src.create "client" ~doc:"vchan client"
   module Log = (val Logs.src_log client_src : Logs.LOG)


### PR DESCRIPTION
V1 is now Mirage_types, and V1_LWT is now Mirage_types_lwt, as of MirageOS version 3.0.0.