### PR TITLE
Update to lwt.3.0.0

### DIFF
--- a/lib/conduit_lwt_server.ml
+++ b/lib/conduit_lwt_server.ml
@@ -15,7 +15,7 @@ let close (ic, oc) =
 let listen ?(backlog=128) sa =
   let fd = Lwt_unix.socket (Unix.domain_of_sockaddr sa) Unix.SOCK_STREAM 0 in
   Lwt_unix.(setsockopt fd SO_REUSEADDR true);
-  Lwt_unix.bind fd sa;
+  Lwt_unix.Versioned.bind_1 fd sa;
   Lwt_unix.listen fd backlog;
   Lwt_unix.set_close_on_exec fd;
   fd

--- a/lib/conduit_lwt_unix.ml
+++ b/lib/conduit_lwt_unix.ml
@@ -170,7 +170,7 @@ module Sockaddr_client = struct
         let () =
           match src with
           | None -> ()
-          | Some src_sa -> Lwt_unix.bind fd src_sa
+          | Some src_sa -> Lwt_unix.Versioned.bind_1 fd src_sa
         in
         Lwt_unix.connect fd sa >>= fun () ->
         let ic = Lwt_io.of_fd ~mode:Lwt_io.input fd in

--- a/opam
+++ b/opam
@@ -39,7 +39,7 @@ depopts: [
   "mirage-flow-lwt"
 ]
 conflicts: [
-  "lwt" {<"2.4.4"}
+  "lwt" {<"2.7.0"}
   "async_ssl" {<"112.24.00"}
   "async" {<"113.24.00"}
   "mirage-flow-lwt" {< "1.2.0"}


### PR DESCRIPTION
Lwt_unix.bind now returns a promise.

Note the signature of `Conduit_lwt_server.listen` has had to change, to also return a promise.

Rleated to ocsigen/lwt#308

Signed-off-by: David Scott <dave@recoil.org>