### PR TITLE
Correct the Findlib package name of lwt_ssl

### DIFF
--- a/discover.ml
+++ b/discover.ml
@@ -86,7 +86,7 @@ end
 let async       = Flag.mk "async" ["async"]
 let async_ssl   = Flag.mk "async_ssl" ["async_ssl"]
 let lwt         = Flag.mk "lwt" ["lwt"]
-let lwt_ssl     = Flag.mk "lwt_ssl" ["lwt.ssl"]
+let lwt_ssl     = Flag.mk "lwt_ssl" ["lwt_ssl"]
 let lwt_tls     = Flag.mk "lwt_tls" ["tls.lwt"]
 let mirage      = Flag.mk "mirage" ["mirage-types-lwt"; "mirage-flow-lwt"; "dns.mirage"]
 let mirage_tls  = Flag.mk "mirage_tls" ["tls"; "tls.mirage"]

--- a/opam
+++ b/opam
@@ -30,6 +30,7 @@ depopts: [
   "lwt"
   "ssl"
   "async_ssl"
+  "lwt_ssl"
   "mirage-dns"
   "vchan"
   "launchd"


### PR DESCRIPTION
OPAM installs lwt_ssl under the Findlib package name of `lwt_ssl`, not `lwt.ssl`. Refer to https://github.com/ocaml/opam-repository/blob/master/packages/lwt_ssl/lwt_ssl.1.0.1/opam#L24
```
remove: [
    ["ocamlfind" "remove" "lwt_ssl"]
]
```

 and https://ocsigen.org/lwt/api/Lwt_ssl:

> This module is provided by OPAM package `lwt_ssl`. Link with ocamlfind package `lwt_ssl`.

The use of the wrong name prevented `discover.ml` from detecting the installed lwt_ssl package.