### PR TITLE
Also pass context certificate to clients.

### DIFF
--- a/lwt-unix/conduit_lwt_tls.ml
+++ b/lwt-unix/conduit_lwt_tls.ml
@@ -24,7 +24,7 @@ module Client = struct
     Conduit_lwt_server.with_socket sa (fun fd ->
         (match src with
          | None -> Lwt.return_unit
-         | Some src_sa -> Lwt_unix.Versioned.bind_2 fd src_sa) >>= fun () ->
+         | Some src_sa -> Lwt_unix.bind fd src_sa) >>= fun () ->
         X509_lwt.authenticator `No_authentication_I'M_STUPID >>= fun authenticator ->
         let config = Tls.Config.client ~authenticator ?certificates () in
         Lwt_unix.connect fd sa >>= fun () ->

--- a/lwt-unix/conduit_lwt_tls.ml
+++ b/lwt-unix/conduit_lwt_tls.ml
@@ -20,13 +20,13 @@ open Lwt.Infix
 let _ = Nocrypto_entropy_lwt.initialize ()
 
 module Client = struct
-  let connect ?src host sa =
+  let connect ?src ?certificates host sa =
     Conduit_lwt_server.with_socket sa (fun fd ->
         (match src with
          | None -> Lwt.return_unit
-         | Some src_sa -> Lwt_unix.bind fd src_sa) >>= fun () ->
+         | Some src_sa -> Lwt_unix.Versioned.bind_2 fd src_sa) >>= fun () ->
         X509_lwt.authenticator `No_authentication_I'M_STUPID >>= fun authenticator ->
-        let config = Tls.Config.client ~authenticator () in
+        let config = Tls.Config.client ~authenticator ?certificates () in
         Lwt_unix.connect fd sa >>= fun () ->
         Tls_lwt.Unix.client_of_fd config ~host fd >|= fun t ->
         let ic, oc = Tls_lwt.of_t t in

--- a/lwt-unix/conduit_lwt_tls.mli
+++ b/lwt-unix/conduit_lwt_tls.mli
@@ -21,6 +21,7 @@ module Client : sig
 
   val connect :
     ?src:Lwt_unix.sockaddr ->
+    ?certificates:Tls.Config.own_cert ->
     string ->
     Lwt_unix.sockaddr ->
     (Lwt_unix.file_descr * Lwt_io.input_channel * Lwt_io.output_channel) Lwt.t

--- a/lwt-unix/conduit_lwt_unix.ml
+++ b/lwt-unix/conduit_lwt_unix.ml
@@ -160,7 +160,7 @@ module Sockaddr_client = struct
     Conduit_lwt_server.with_socket sa (fun fd ->
         (match src with
          | None -> Lwt.return_unit
-         | Some src_sa -> Lwt_unix.Versioned.bind_2 fd src_sa) >>= fun () ->
+         | Some src_sa -> Lwt_unix.bind fd src_sa) >>= fun () ->
         Lwt_unix.connect fd sa >>= fun () ->
         let ic = Lwt_io.of_fd ~mode:Lwt_io.input fd in
         let oc = Lwt_io.of_fd ~mode:Lwt_io.output fd in

--- a/lwt-unix/conduit_lwt_unix.mli
+++ b/lwt-unix/conduit_lwt_unix.mli
@@ -129,13 +129,17 @@ type flow = private
 [@@deriving sexp_of]
 
 (** Type describing where to locate a PEM key in the filesystem *)
-type tls_server_key = [
+type tls_own_key = [
  | `None
  | `TLS of
     [ `Crt_file_path of string ] *
     [ `Key_file_path of string ] *
     [ `Password of bool -> string | `No_password ]
 ] [@@deriving sexp]
+
+(**/**)
+type tls_server_key = tls_own_key [@@deriving sexp] [@@deprecated "Renamed to tls_own_key."]
+(**/**)
 
 (** State handler for an active conduit *)
 type ctx [@@deriving sexp_of]
@@ -146,11 +150,15 @@ type ctx [@@deriving sexp_of]
     no TLS certificate associated with the Conduit *)
 val default_ctx : ctx
 
-(** [init ?src ?tls_server_key ()] will initialize a Unix conduit
+(** [init ?src ?tls_own_key ()] will initialize a Unix conduit
     that binds to the [src] interface if specified.  If TLS server
     connections are used, then [tls_server_key] must contain a
     valid certificate to be used to advertise a TLS connection *)
-val init : ?src:string -> ?tls_server_key:tls_server_key -> unit -> ctx io
+val init :
+  ?src:string ->
+  ?tls_own_key:tls_own_key ->
+  ?tls_server_key:tls_own_key (* Deprecated, use tls_own_key. *) ->
+  unit -> ctx io
 
 (** [connect ~ctx client] establishes an outgoing connection
     via the [ctx] context to the endpoint described by [client] *)

--- a/lwt-unix/conduit_lwt_unix_ssl_dummy.ml
+++ b/lwt-unix/conduit_lwt_unix_ssl_dummy.ml
@@ -20,6 +20,8 @@ open Lwt.Infix
 module Client = struct
   let default_ctx = `Ssl_not_available
 
+  let create_ctx ?certfile ?keyfile ?password () = default_ctx
+
   let connect ?(ctx=default_ctx) ?src sa = Lwt.fail_with "Ssl not available"
 end
 

--- a/lwt-unix/conduit_lwt_unix_ssl_dummy.mli
+++ b/lwt-unix/conduit_lwt_unix_ssl_dummy.mli
@@ -20,6 +20,12 @@
 module Client : sig
   val default_ctx : [`Ssl_not_available]
 
+  val create_ctx :
+    ?certfile:string ->
+    ?keyfile:string ->
+    ?password:(bool -> string) ->
+    unit -> [`Ssl_not_available]
+
   val connect :
     ?ctx:[`Ssl_not_available] ->
     ?src:Lwt_unix.sockaddr ->

--- a/lwt-unix/conduit_lwt_unix_ssl_real.ml
+++ b/lwt-unix/conduit_lwt_unix_ssl_real.ml
@@ -28,8 +28,19 @@ let chans_of_fd sock =
 
 module Client = struct
   (* SSL TCP connection *)
-  let default_ctx = Ssl.create_context Ssl.SSLv23 Ssl.Client_context
-  let () = Ssl.disable_protocols default_ctx [Ssl.SSLv23]
+
+  let create_ctx ?certfile ?keyfile ?password () =
+    let ctx = Ssl.create_context Ssl.SSLv23 Ssl.Client_context in
+    Ssl.disable_protocols ctx [Ssl.SSLv23];
+    (match certfile, keyfile with
+     | Some certfile, Some keyfile -> Ssl.use_certificate ctx certfile keyfile
+     | None, _ | _, None -> ());
+    (match password with
+     | Some password -> Ssl.set_password_callback ctx password
+     | None -> ());
+    ctx
+
+  let default_ctx = create_ctx ()
 
   let connect ?(ctx=default_ctx) ?src sa =
     Conduit_lwt_server.with_socket sa (fun fd ->

--- a/lwt-unix/conduit_lwt_unix_ssl_real.mli
+++ b/lwt-unix/conduit_lwt_unix_ssl_real.mli
@@ -20,6 +20,12 @@
 module Client : sig
   val default_ctx : Ssl.context
 
+  val create_ctx :
+    ?certfile:string ->
+    ?keyfile:string ->
+    ?password:(bool -> string) ->
+    unit -> Ssl.context
+
   val connect :
     ?ctx:Ssl.context ->
     ?src:Lwt_unix.sockaddr ->


### PR DESCRIPTION
This is a sketch of how we might add TLS client authentication. We may want to revise it before merging:

In the server, the local certificate is passed though the `server` type though `server_tls_config`. If I were to do the same with the `client_tls_config` type, I would break backwards compatibility due to the concrete type. The alternative of adding more constructors to `client` seems inelegant. The current patch avoids compatibility issues but only allows passing the key though the context.

Also note, I renamed the type and keyword argument `tls_server_key` to `tls_own_key`. I considered "peer" but "own" makes it clear that it's the local peer and the word was used in `Tls.Config`. But more essentially, we could have separated the server and client keys in the context. The type might still be the same. I left aliases `tls_server_key` for backwards compatibility. (If we wanted to select between multiple keys, we could consider passing a function which receives information about the connection which is about to be established.)