### PR TITLE
Use Astring instead of Stringext

### DIFF
--- a/conduit.opam
+++ b/conduit.opam
@@ -15,7 +15,7 @@ depends: [
   "jbuilder" {build & >="1.0+beta9"}
   "ppx_sexp_conv" {build}
   "sexplib"
-  "stringext"
+  "astring"
   "uri"
   "result"
   "logs" {>="0.5.0"}

--- a/lib/jbuild
+++ b/lib/jbuild
@@ -5,4 +5,4 @@
   (wrapped false)
   (preprocess (pps (ppx_sexp_conv)))
   (modules (conduit conduit_trie resolver))
-  (libraries (ipaddr uri))))
+  (libraries (ipaddr uri astring))))

--- a/lib/resolver.ml
+++ b/lib/resolver.ml
@@ -16,6 +16,7 @@
  *)
 
 open Sexplib.Std
+open Astring
 
 type service = {
   name: string;
@@ -112,7 +113,7 @@ module Make(IO:Conduit.IO) = struct
 
   let host_to_domain_list host =
     (* TODO: slow, specialise the Trie to be a rev string list instead *)
-    String.concat "." (List.rev (Stringext.split ~on:'.' host))
+    String.concat ~sep:"." (List.rev (String.cuts ~sep:"." host))
 
   let add_rewrite ~host ~f t =
     t.domains <- Conduit_trie.insert (host_to_domain_list host) f t.domains


### PR DESCRIPTION
Otherwise, fails with:

```
(cd _build/default && /home/opam/.opam/ocaml-base-compiler.4.04.2/bin/ocamlc.opt -w -40 -g -bin-annot -I /home/opam/.opam/ocaml-base-compiler.4.04.2/lib/bytes -I /home/opam/.opam/ocaml-base-compiler.4.04.2/lib/ipaddr -I /home/opam/.opam/ocaml-base-compiler.4.04.2/lib/ocaml -I /home/opam/.opam/ocaml-base-compiler.4.04.2/lib/re -I /home/opam/.opam/ocaml-base-compiler.4.04.2/lib/sexplib -I /home/opam/.opam/ocaml-base-compiler.4.04.2/lib/uri -no-alias-deps -I lib -o lib/resolver.cmo -c -impl lib/resolver.pp.ml)
# File "lib/resolver.ml", line 115, characters 33-48:
# Error: Unbound module Stringext
# Hint: Did you mean String?
```

Seen on https://github.com/ocaml/opam-repository/pull/9824