### PR TITLE
Fix mirage-conduit ocamlfind dependencies

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,9 +5,9 @@ environment:
   CYG_ROOT: "C:\\cygwin"
   CYG_BASH: "%CYG_ROOT%\\bin\\bash -lc"
   TESTS: "false"
-  PINS: "conduit.0.15.0:. mirage-conduit:."
+  PINS: "conduit.dev:. conduit-lwt.dev:. mirage-conduit.dev:."
   EXTRA_REMOTES: "https://github.com/mirage/mirage-dev.git"
-  PACKAGE: "mirage-conduit"
+  PACKAGE: "mirage-conduit.dev"
 
 install:
   - appveyor DownloadFile https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/appveyor-opam.sh

--- a/mirage-conduit.opam
+++ b/mirage-conduit.opam
@@ -11,13 +11,14 @@ build: [
   ["jbuilder" "subst" "-p" name "--name" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
+build-test: ["jbuilder" "runtest" "-p" name]
 
 depends: [
   "cstruct"          {>= "3.0.0"}
   "mirage-types-lwt" {>= "3.0.0"}
   "mirage-flow-lwt"  {>= "1.2.0"}
   "mirage-dns"       {>= "3.0.0"}
-  "conduit-lwt" 
+  "conduit-lwt"
   "vchan"            {>= "3.0.0"}
   "tls"              {>="0.8.0"}
 ]

--- a/mirage/jbuild
+++ b/mirage/jbuild
@@ -5,4 +5,5 @@
   (preprocess (pps (ppx_sexp_conv)))
   (modules (conduit_mirage resolver_mirage conduit_xenstore))
   (wrapped false)
-  (libraries (conduit conduit-lwt mirage-types-lwt mirage-dns vchan tls tls.lwt))))
+  (libraries (conduit conduit-lwt mirage-types-lwt mirage-dns vchan
+              tls tls.mirage))))

--- a/tests/mirage/simple/jbuild
+++ b/tests/mirage/simple/jbuild
@@ -1,0 +1,11 @@
+(jbuild_version 1)
+
+(executable
+  ((name      test)
+   (libraries (mirage-conduit))))
+
+(alias
+ ((name    runtest)
+  (package mirage-conduit)
+  (deps    (test.exe))
+  (action  (run ${exe:test.exe} --color=always))))

--- a/tests/mirage/simple/test.ml
+++ b/tests/mirage/simple/test.ml
@@ -1,0 +1,10 @@
+(* this is just to test that linking works properly *)
+
+let client: Conduit_mirage.client =
+  `TCP (Ipaddr.of_string_exn "127.0.0.1", 12345)
+
+let server: Conduit_mirage.server =
+  `TCP 12345
+
+let _client () = Conduit_mirage.(connect empty) client
+let _server () = Conduit_mirage.(listen empty) server


### PR DESCRIPTION
Otherwise, we get:

```
File "_none_", line 1:
Error: No implementations provided for the following modules:
         Tls_mirage referenced from /Users/thomas/.opam/vpnkit/lib/mirage-conduit/conduit_mirage.cmxa(Conduit_mirage)
```

when linking