### PR TITLE
Detect Lwt SSL/TLS version actively at runtime

### DIFF
--- a/lwt-unix/conduit_lwt_tls_dummy.ml
+++ b/lwt-unix/conduit_lwt_tls_dummy.ml
@@ -10,3 +10,5 @@ module Server = struct
   let init ?backlog ~certfile ~keyfile ?stop ?timeout sa callback =
     Lwt.fail_with "Tls not available"
 end
+
+let available = false

--- a/lwt-unix/conduit_lwt_tls_dummy.mli
+++ b/lwt-unix/conduit_lwt_tls_dummy.mli
@@ -53,3 +53,7 @@ module Server : sig
         -> unit Lwt.t)
     -> unit Lwt.t
 end
+
+(**/**)
+
+val available : bool

--- a/lwt-unix/conduit_lwt_tls_real.ml
+++ b/lwt-unix/conduit_lwt_tls_real.ml
@@ -62,3 +62,5 @@ module Server = struct
     let config = Tls.Config.server ~certificates:(`Single certificate) () in
     init' ?backlog ?stop ?timeout config sa callback
 end
+
+let available = true

--- a/lwt-unix/conduit_lwt_tls_real.mli
+++ b/lwt-unix/conduit_lwt_tls_real.mli
@@ -53,3 +53,7 @@ module Server : sig
         -> unit Lwt.t)
     -> unit Lwt.t
 end
+
+(**/**)
+
+val available : bool

--- a/lwt-unix/conduit_lwt_unix.ml
+++ b/lwt-unix/conduit_lwt_unix.ml
@@ -32,6 +32,8 @@ let default_tls_library =
   try
     match String.lowercase_ascii (Sys.getenv "CONDUIT_TLS") with
     | "native" -> Native
+    | "openssl" | "libressl" -> OpenSSL
+    | "none" | "notls" -> No_tls
     | _ -> OpenSSL
   with Not_found ->
     if Conduit_lwt_unix_ssl.available then

--- a/lwt-unix/conduit_lwt_unix.ml
+++ b/lwt-unix/conduit_lwt_unix.ml
@@ -29,20 +29,21 @@ let () =
 
 type tls_lib = | OpenSSL | Native | No_tls [@@deriving sexp]
 let default_tls_library =
-  try
-    match String.lowercase_ascii (Sys.getenv "CONDUIT_TLS") with
-    | "native" -> Native
-    | "openssl" | "libressl" -> OpenSSL
-    | "none" | "notls" -> No_tls
-    | _ -> OpenSSL
-  with Not_found ->
-    if Conduit_lwt_unix_ssl.available then
-      OpenSSL
-    else if Conduit_lwt_tls.available then
+  (* TODO build time selection *)
+  let default =
+    if Conduit_lwt_tls.available then
       Native
+    else if Conduit_lwt_unix_ssl.available then
+      OpenSSL
     else
       No_tls
-  (* TODO build time selection *)
+  in
+  match String.lowercase_ascii (Sys.getenv "CONDUIT_TLS") with
+  | "native" -> Native
+  | "openssl" | "libressl" -> OpenSSL
+  | "none" | "notls" -> No_tls
+  | _ -> default
+  | exception  Not_found -> default
 
 let tls_library = ref default_tls_library
 

--- a/lwt-unix/conduit_lwt_unix_ssl_dummy.ml
+++ b/lwt-unix/conduit_lwt_unix_ssl_dummy.ml
@@ -34,3 +34,5 @@ module Server = struct
       ?timeout sa cb =
     Lwt.fail_with "Ssl not available"
 end
+
+let available = false

--- a/lwt-unix/conduit_lwt_unix_ssl_dummy.mli
+++ b/lwt-unix/conduit_lwt_unix_ssl_dummy.mli
@@ -46,3 +46,7 @@ module Server : sig
         -> unit Lwt.t)
     -> unit Lwt.t
 end
+
+(**/**)
+
+val available : bool

--- a/lwt-unix/conduit_lwt_unix_ssl_real.ml
+++ b/lwt-unix/conduit_lwt_unix_ssl_real.ml
@@ -68,3 +68,5 @@ module Server = struct
         >>= Conduit_lwt_server.process_accept ?timeout cb)
 
 end
+
+let available = true

--- a/lwt-unix/conduit_lwt_unix_ssl_real.mli
+++ b/lwt-unix/conduit_lwt_unix_ssl_real.mli
@@ -46,3 +46,7 @@ module Server : sig
         -> unit Lwt.t)
     -> unit Lwt.t
 end
+
+(**/**)
+
+val available : bool


### PR DESCRIPTION
This adds a flag to the `dummy`/`real` modules to indicate their real-ness then at run time uses that flag information when the `CONDUIT_TLS` environment variable is not specified to select `OpenSSL`/`Native`/`No_tls` in `Conduit_lwt_unix`.

This should fix #233 