### PR TITLE
Fix build dependencies

### DIFF
--- a/conduit-lwt-unix.opam
+++ b/conduit-lwt-unix.opam
@@ -14,6 +14,7 @@ build: [
 depends: [
   "base-unix"
   "jbuilder" {build & >="1.0+beta9"}
+  "ppx_sexp_conv" {build}
   "conduit-lwt"
   "lwt"
   "uri" {>="1.9.4"}

--- a/conduit-lwt.opam
+++ b/conduit-lwt.opam
@@ -14,6 +14,7 @@ build: [
 depends: [
   "base-unix"
   "jbuilder" {build & >="1.0+beta9"}
+  "ppx_sexp_conv" {build}
   "conduit"
   "lwt" {>="3.0.0"}
 ]

--- a/mirage-conduit.opam
+++ b/mirage-conduit.opam
@@ -14,6 +14,8 @@ build: [
 build-test: ["jbuilder" "runtest" "-p" name]
 
 depends: [
+  "jbuilder" {build & >="1.0+beta9"}
+  "ppx_sexp_conv" {build}
   "cstruct"          {>= "3.0.0"}
   "mirage-types-lwt" {>= "3.0.0"}
   "mirage-flow-lwt"  {>= "1.2.0"}


### PR DESCRIPTION
Not specifying these could cause some weird races, where the ppx drivers are
removed while the library is being built.

See https://travis-ci.org/mirage/irmin/jobs/260197274 for an example