### PR TITLE
Fix launchd backend

### DIFF
--- a/lwt-unix/jbuild
+++ b/lwt-unix/jbuild
@@ -7,8 +7,8 @@
   (modules (resolver_lwt_unix conduit_lwt_unix conduit_lwt_server conduit_lwt_tls conduit_lwt_unix_ssl conduit_lwt_launchd))
   (libraries (conduit-lwt lwt.unix uri.services ipaddr.unix logs
     (select conduit_lwt_launchd.ml from
-     (launchd  -> conduit_lwt_launchd_real.ml)
-     (!launchd -> conduit_lwt_launchd_dummy.ml))
+     (launchd.lwt  -> conduit_lwt_launchd_real.ml)
+     (!launchd.lwt -> conduit_lwt_launchd_dummy.ml))
     (select conduit_lwt_unix_ssl.ml from
      (lwt_ssl  -> conduit_lwt_unix_ssl_real.ml)
      (!lwt_ssl -> conduit_lwt_unix_ssl_dummy.ml))


### PR DESCRIPTION
Otherwise this gives:

```
Error: No implementations provided for the following modules:
         Lwt_launchd referenced from /Users/thomas/.opam/conduit/lib/conduit-lwt-unix/conduit_lwt_unix.cmxa(Conduit_lwt_launchd)
```

(built on top of #239 to fix the SSL backend compilation)