### PR TITLE
Favor resolving into IPv4 over IPv6

### DIFF
--- a/lwt-unix/resolver_lwt_unix.ml
+++ b/lwt-unix/resolver_lwt_unix.ml
@@ -77,7 +77,10 @@ let system_resolver service uri =
   let host = get_host uri in
   let port = get_port service uri in
   getaddrinfo host (string_of_int port) [AI_SOCKTYPE SOCK_STREAM]
-  >>= function
+  >>= fun addrinfos ->
+  (* In case both IPv4 and IPv6 addresses exist, favor IPv4: *)
+  let v4, rest = List.partition (fun i -> i.ai_family = PF_INET) addrinfos in
+  match List.rev_append v4 rest with
   | [] -> return_endp "system" service uri (`Unknown ("name resolution failed"))
   | {ai_addr=ADDR_INET (addr,port);_}::_ ->
      return_endp "system" service uri


### PR DESCRIPTION
If the server is listening to both it would make little difference.  If the
server is listening only to IPv4, as does cohttp, then it makes the endpoint
usable. If the server is listening only to IPv6, as does no HTTP server I know
about, then the endpoint is now broken.

A better fix would be to keep all addresses and try them all in turn, as
suggested in #244.