### PR TITLE
Depend on xenstore for mirage-conduit directly

### DIFF
--- a/mirage-conduit.opam
+++ b/mirage-conduit.opam
@@ -22,6 +22,7 @@ depends: [
   "mirage-dns"       {>= "3.0.0"}
   "conduit-lwt"
   "vchan"            {>= "3.0.0"}
+  "xenstore"
   "tls"              {>="0.8.0"}
 ]
 available: [ocaml-version >="4.03.0"]

--- a/mirage/jbuild
+++ b/mirage/jbuild
@@ -6,4 +6,4 @@
   (modules (conduit_mirage resolver_mirage conduit_xenstore))
   (wrapped false)
   (libraries (conduit conduit-lwt mirage-types-lwt mirage-dns vchan
-              tls tls.mirage))))
+              tls tls.mirage xenstore.client))))


### PR DESCRIPTION
Xenstore is being used directly in conduit_xenstore so we should explicitly depend on it rather than relying on vchan to pull it in.