### PR TITLE
compile against async_extra v0.9.116.03+91

### DIFF
--- a/async/conduit_async.ml
+++ b/async/conduit_async.ml
@@ -33,22 +33,22 @@ type addr = [
 let connect ?interrupt dst =
   match dst with
   | `TCP (ip, port) -> begin
-      Tcp.connect ?interrupt (Tcp.to_host_and_port (Ipaddr.to_string ip) port)
+      Tcp.connect ?interrupt (Tcp.Where_to_connect.of_host_and_port { host = Ipaddr.to_string ip; port })
       >>= fun (_, rd, wr) -> return (rd,wr)
   end
   | `OpenSSL (_, ip, port) -> begin
-      Tcp.connect ?interrupt (Tcp.to_host_and_port (Ipaddr.to_string ip) port)
+      Tcp.connect ?interrupt (Tcp.Where_to_connect.of_host_and_port { host = Ipaddr.to_string ip; port })
       >>= fun (_, rd, wr) ->
       let config = Conduit_async_ssl.Ssl_config.configure () in
       Conduit_async_ssl.ssl_connect config rd wr
   end
   | `OpenSSL_with_config (_, ip, port, config) -> begin
-      Tcp.connect ?interrupt (Tcp.to_host_and_port (Ipaddr.to_string ip) port)
+      Tcp.connect ?interrupt (Tcp.Where_to_connect.of_host_and_port { host = Ipaddr.to_string ip; port })
       >>= fun (_, rd, wr) ->
       Conduit_async_ssl.ssl_connect config rd wr
   end
   | `Unix_domain_socket file -> begin
-      Tcp.connect ?interrupt (Tcp.to_file file)
+      Tcp.connect ?interrupt (Tcp.Where_to_connect.of_file file)
       >>= fun (_, rd, wr) ->
       return (rd,wr)
   end
@@ -57,13 +57,13 @@ let with_connection ?interrupt dst f =
   match dst with
   | `TCP (ip, port) -> begin
       Tcp.with_connection ?interrupt
-        (Tcp.to_host_and_port (Ipaddr.to_string ip) port)
+        (Tcp.Where_to_connect.of_host_and_port { host = Ipaddr.to_string ip; port })
         (fun _ rd wr -> f rd wr)
     end
   | `OpenSSL (_, ip, port) -> begin
     let config = Conduit_async_ssl.Ssl_config.configure () in
     Tcp.with_connection ?interrupt
-    (Tcp.to_host_and_port (Ipaddr.to_string ip) port) begin fun _ rd wr ->
+    (Tcp.Where_to_connect.of_host_and_port { host = Ipaddr.to_string ip; port }) begin fun _ rd wr ->
     Conduit_async_ssl.ssl_connect config rd wr >>= fun (rd, wr) ->
     Monitor.protect (fun () -> f rd wr) ~finally:begin fun () ->
       Deferred.all_unit [ Reader.close rd ; Writer.close wr ]
@@ -72,7 +72,7 @@ let with_connection ?interrupt dst f =
   end
   | `OpenSSL_with_config (_, ip, port, config) -> begin
     Tcp.with_connection ?interrupt
-    (Tcp.to_host_and_port (Ipaddr.to_string ip) port) begin fun _ rd wr ->
+    (Tcp.Where_to_connect.of_host_and_port { host = Ipaddr.to_string ip; port }) begin fun _ rd wr ->
      Conduit_async_ssl.ssl_connect config rd wr >>= fun (rd, wr) ->
      Monitor.protect (fun () -> f rd wr) ~finally:begin fun () ->
        Deferred.all_unit [ Reader.close rd ; Writer.close wr ]
@@ -80,7 +80,7 @@ let with_connection ?interrupt dst f =
     end
   end
   | `Unix_domain_socket file -> begin
-    Tcp.with_connection ?interrupt (Tcp.to_file file)
+    Tcp.with_connection ?interrupt (Tcp.Where_to_connect.of_file file)
       (fun _ rd wr -> f rd wr)
   end
 
@@ -110,7 +110,7 @@ type server = [
 
 let serve
       ?max_connections ?backlog
-      ?buffer_age_limit ?on_handler_error mode where_to_listen handle_request =
+      ?buffer_age_limit ?(on_handler_error=`Ignore) mode where_to_listen handle_request =
   let handle_client handle_request sock rd wr =
     match mode with
     | `TCP -> handle_request sock rd wr
@@ -138,5 +138,5 @@ let serve
               Deferred.all_unit [ Reader.close rd ; Writer.close wr ])
     in
     Tcp.Server.create ?max_connections ?backlog
-      ?buffer_age_limit ?on_handler_error
+      ?buffer_age_limit ~on_handler_error
       where_to_listen (handle_client handle_request)

--- a/async/conduit_async.ml
+++ b/async/conduit_async.ml
@@ -110,7 +110,7 @@ type server = [
 
 let serve
       ?max_connections ?backlog
-      ?buffer_age_limit ?(on_handler_error=`Ignore) mode where_to_listen handle_request =
+      ?buffer_age_limit ?(on_handler_error=`Raise) mode where_to_listen handle_request =
   let handle_client handle_request sock rd wr =
     match mode with
     | `TCP -> handle_request sock rd wr


### PR DESCRIPTION
I'm using [janestreet/opam-repository](/janestreet/opam-repository) and needed to make these changes to compile against it. I guess this shouldn't be merged until the next JS package release hits opam, but this is (a subset of) what will be necessary when that happens :)