### PR TITLE
Force users to give a custom callback in case of exception to avoid random crashes

### DIFF
--- a/lwt-unix/conduit_lwt_unix.ml
+++ b/lwt-unix/conduit_lwt_unix.ml
@@ -318,7 +318,7 @@ let serve_with_default_tls ?timeout ?stop ~ctx ~certfile ~keyfile
   | No_tls -> failwith "No SSL or TLS support compiled into Conduit"
 
 let serve ?backlog ?timeout ?stop
-    ?(on_exn=(fun exn -> !Lwt.async_exception_hook exn))
+    ~on_exn
     ~(ctx:ctx) ~(mode:server) callback =
   let callback flow ic oc =
     Lwt.catch

--- a/lwt-unix/conduit_lwt_unix.mli
+++ b/lwt-unix/conduit_lwt_unix.mli
@@ -80,7 +80,7 @@ type tcp_config = [
   | `Socket of Lwt_unix.file_descr sexp_opaque
 ] [@@deriving sexp]
 
-(** Set of supported listening mechanisms that are supported by this module. 
+(** Set of supported listening mechanisms that are supported by this module.
    - [`TLS server_tls_config]: Use OCaml-TLS or OpenSSL (depending on CONDUIT_TLS) to connect
      to the given [host], [ip], [port] tuple via TCP.
    - [`TLS_native _]: Force use of native OCaml TLS stack to connect.
@@ -166,7 +166,7 @@ val init : ?src:string -> ?tls_server_key:tls_server_key -> unit -> ctx io
     via the [ctx] context to the endpoint described by [client] *)
 val connect : ctx:ctx -> client -> (flow * ic * oc) io
 
-(** [serve ?backlog ?timeout ?stop ?on_exn ~ctx ~mode fn]
+(** [serve ?backlog ?timeout ?stop ~on_exn ~ctx ~mode fn]
     establishes a listening connection of type [mode], using the [ctx]
     context.  The [stop] thread will terminate the server if it ever
     becomes determined.  Every connection will be served in a new
@@ -174,10 +174,10 @@ val connect : ctx:ctx -> client -> (flow * ic * oc) io
     [fn] callback is passed the {!flow} representing the client
     connection and the associated input {!ic} and output {!oc}
     channels. If the callback raises an exception, it is passed to
-    [on_exn] (by default, to !Lwt.async_exception_hook). *)
+    [on_exn]. *)
 val serve :
   ?backlog:int -> ?timeout:int -> ?stop:(unit io) ->
-  ?on_exn:(exn -> unit) -> ctx:ctx -> mode:server ->
+  on_exn:(exn -> unit) -> ctx:ctx -> mode:server ->
   (flow -> ic -> oc -> unit io) -> unit io
 
 (** [set_max_active nconn] sets the maximum number of active connections


### PR DESCRIPTION
When using Conduit_lwt_unix.serve with cohttp, for instance, in a very simple http server that serves files, the server crashes with an exception when the connexion is cut while the server is trying to send the response. For example this happens very frequently if you are spamming Ctrl-R on your browser.

This happens because the ```on_exn``` parameter defaults to ```print an error message with a backtrace if available and to exit the program``` (quote from the ```Lwt.async_exception_hook``` documentation).

My proposal is simple: it is really easy to make this mistake, the error is quite difficult to understand and might happens at any moment, and therefore the user should be forced to choose what to do in case an exception is raised.

cc @rgrinberg 