### PR TITLE
require ppx_sexp_conv < v0.11.0

### DIFF
--- a/conduit-lwt-unix.opam
+++ b/conduit-lwt-unix.opam
@@ -14,7 +14,7 @@ build: [
 depends: [
   "base-unix"
   "jbuilder" {build & >="1.0+beta9"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11.0"}
   "conduit-lwt"
   "lwt" {>= "3.0.0"}
   "uri" {>="1.9.4"}

--- a/conduit-lwt.opam
+++ b/conduit-lwt.opam
@@ -14,7 +14,7 @@ build: [
 depends: [
   "base-unix"
   "jbuilder" {build & >="1.0+beta9"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11.0"}
   "sexplib"
   "conduit"
   "lwt" {>="3.0.0"}

--- a/conduit.opam
+++ b/conduit.opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "jbuilder" {build & >="1.0+beta9"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11.0"}
   "sexplib"
   "astring"
   "uri"

--- a/mirage-conduit.opam
+++ b/mirage-conduit.opam
@@ -15,7 +15,7 @@ build-test: ["jbuilder" "runtest" "-p" name]
 
 depends: [
   "jbuilder" {build & >="1.0+beta9"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11.0"}
   "sexplib"
   "cstruct"          {>= "3.0.0"}
   "mirage-types-lwt" {>= "3.0.0"}


### PR DESCRIPTION
as additional question for @avsm: why does `conduit-lwt.opam` include a `"base-unix"` dependency (added by you) -- shouldn't `conduit-lwt` be free of unix?