### PR TITLE
Get client IP when using TLS/SSH connections

### DIFF
--- a/lwt-unix/conduit_lwt_tls_dummy.mli
+++ b/lwt-unix/conduit_lwt_tls_dummy.mli
@@ -35,7 +35,8 @@ module Server : sig
     -> ?stop:(unit Lwt.t)
     -> ?timeout:int
     -> Lwt_unix.sockaddr
-    -> (Lwt_unix.file_descr
+    -> (Lwt_unix.sockaddr
+        -> Lwt_unix.file_descr
         -> Lwt_io.input_channel
         -> Lwt_io.output_channel
         -> unit Lwt.t)
@@ -47,7 +48,8 @@ module Server : sig
     -> ?timeout:int
     -> 'config
     -> Lwt_unix.sockaddr
-    -> (Lwt_unix.file_descr
+    -> (Lwt_unix.sockaddr
+        -> Lwt_unix.file_descr
         -> Lwt_io.input_channel
         -> Lwt_io.output_channel
         -> unit Lwt.t)

--- a/lwt-unix/conduit_lwt_tls_real.ml
+++ b/lwt-unix/conduit_lwt_tls_real.ml
@@ -39,14 +39,14 @@ module Server = struct
   let init' ?backlog ?stop ?timeout tls sa callback =
     sa
     |> Conduit_lwt_server.listen ?backlog
-    >>= Conduit_lwt_server.init ?stop (fun (fd, _) ->
+    >>= Conduit_lwt_server.init ?stop (fun (fd, addr) ->
         Lwt.try_bind
           (fun () -> Tls_lwt.Unix.server_of_fd tls fd)
           (fun t ->
              let (ic, oc) = Tls_lwt.of_t t in
              Lwt.return (fd, ic, oc))
           (fun exn -> Lwt_unix.close fd >>= fun () -> Lwt.fail exn)
-        >>= Conduit_lwt_server.process_accept ?timeout callback)
+        >>= Conduit_lwt_server.process_accept ?timeout (callback addr))
 
   let init ?backlog ~certfile ~keyfile ?stop ?timeout sa callback =
     X509_lwt.private_of_pems ~cert:certfile ~priv_key:keyfile

--- a/lwt-unix/conduit_lwt_tls_real.mli
+++ b/lwt-unix/conduit_lwt_tls_real.mli
@@ -35,7 +35,8 @@ module Server : sig
     -> ?stop:(unit Lwt.t)
     -> ?timeout:int
     -> Lwt_unix.sockaddr
-    -> (Lwt_unix.file_descr
+    -> ( Lwt_unix.sockaddr
+        -> Lwt_unix.file_descr
         -> Lwt_io.input_channel
         -> Lwt_io.output_channel
         -> unit Lwt.t)
@@ -47,7 +48,8 @@ module Server : sig
     -> ?timeout:int
     -> Tls.Config.server
     -> Lwt_unix.sockaddr
-    -> (Lwt_unix.file_descr
+    -> (Lwt_unix.sockaddr
+        -> Lwt_unix.file_descr
         -> Lwt_io.input_channel
         -> Lwt_io.output_channel
         -> unit Lwt.t)

--- a/lwt-unix/conduit_lwt_unix.ml
+++ b/lwt-unix/conduit_lwt_unix.ml
@@ -252,7 +252,7 @@ let sockaddr_on_tcp_port ctx port =
 
 let serve_with_openssl ?timeout ?stop ~ctx ~certfile ~keyfile
                        ~pass ~port callback =
-  let sockaddr, ip = sockaddr_on_tcp_port ctx port in
+  let sockaddr, _ = sockaddr_on_tcp_port ctx port in
   let password =
     match pass with
     | `No_password -> None
@@ -260,18 +260,18 @@ let serve_with_openssl ?timeout ?stop ~ctx ~certfile ~keyfile
   in
   Conduit_lwt_unix_ssl.Server.init
     ?password ~certfile ~keyfile ?timeout ?stop sockaddr
-    (fun fd ic oc -> callback (TCP {fd;ip;port}) ic oc)
+    (fun addr fd ic oc -> callback (flow_of_fd fd addr) ic oc)
 
 let serve_with_tls_native ?timeout ?stop ~ctx ~certfile ~keyfile
                           ~pass ~port callback =
-  let sockaddr, ip = sockaddr_on_tcp_port ctx port in
+  let sockaddr, _ = sockaddr_on_tcp_port ctx port in
   (match pass with
     | `No_password -> Lwt.return ()
     | `Password _ -> Lwt.fail_with "OCaml-TLS cannot handle encrypted pem files"
   ) >>= fun () ->
   Conduit_lwt_tls.Server.init
     ~certfile ~keyfile ?timeout ?stop sockaddr
-    (fun fd ic oc -> callback (TCP {fd;ip;port}) ic oc)
+    (fun addr fd ic oc -> callback (flow_of_fd fd addr) ic oc)
 
 let serve_with_default_tls ?timeout ?stop ~ctx ~certfile ~keyfile
     ~pass ~port callback =

--- a/lwt-unix/conduit_lwt_unix_ssl_dummy.mli
+++ b/lwt-unix/conduit_lwt_unix_ssl_dummy.mli
@@ -41,7 +41,8 @@ module Server : sig
     -> ?stop:(unit Lwt.t)
     -> ?timeout:int
     -> Lwt_unix.sockaddr
-    -> (Lwt_unix.file_descr
+    -> (Lwt_unix.sockaddr
+        -> Lwt_unix.file_descr
         -> Lwt_io.input_channel
         -> Lwt_io.output_channel
         -> unit Lwt.t)

--- a/lwt-unix/conduit_lwt_unix_ssl_real.ml
+++ b/lwt-unix/conduit_lwt_unix_ssl_real.ml
@@ -68,11 +68,11 @@ module Server = struct
       ?timeout sa cb =
     sa
     |> listen ~ctx ?backlog ?password ~certfile ~keyfile
-    >>= Conduit_lwt_server.init ?stop (fun (fd, _) ->
+    >>= Conduit_lwt_server.init ?stop (fun (fd, addr) ->
         Lwt.try_bind (fun () -> Lwt_ssl.ssl_accept fd ctx)
           (fun sock -> Lwt.return (chans_of_fd sock))
           (fun exn -> Lwt_unix.close fd >>= fun () -> Lwt.fail exn)
-        >>= Conduit_lwt_server.process_accept ?timeout cb)
+        >>= Conduit_lwt_server.process_accept ?timeout (cb addr))
 
 end
 

--- a/lwt-unix/conduit_lwt_unix_ssl_real.mli
+++ b/lwt-unix/conduit_lwt_unix_ssl_real.mli
@@ -41,7 +41,8 @@ module Server : sig
     -> ?stop:(unit Lwt.t)
     -> ?timeout:int
     -> Lwt_unix.sockaddr
-    -> (Lwt_unix.file_descr
+    -> (Lwt_unix.sockaddr
+        -> Lwt_unix.file_descr
         -> Lwt_io.input_channel
         -> Lwt_io.output_channel
         -> unit Lwt.t)


### PR DESCRIPTION
This is related to issue #188 
The client IP and port wasn't properly propagated.