### PR TITLE
LICENSE.md: add title and copyright notice

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,7 @@
+## ISC License
+
+Copyright (c) 2014-2018 The ocaml-conduit contributors
+
 Permission to use, copy, modify, and/or distribute this software for
 any purpose with or without fee is hereby granted, provided that the
 above copyright notice and this permission notice appear in all


### PR DESCRIPTION
The title is optional (but useful), but the copyright notice is actually part of the legal text (as indicated by the first paragraph of the license).

Note: This is part of a series of PRs submitted to repos in the mirage organization, along the lines of mirage/jitsu#36 (2016), mirage/irmin#472 (2017) and mirage/mirage#905 (2018).