### PR TITLE
add server type (`Listening_socket of Lwt_unix.file_descr)

### DIFF
--- a/lwt-unix/conduit_lwt_unix.ml
+++ b/lwt-unix/conduit_lwt_unix.ml
@@ -89,6 +89,7 @@ type server = [
   | `Vchan_direct of int * string
   | `Vchan_domain_socket of string  * string
   | `Launchd of string
+  | `Listening_socket of Lwt_unix.file_descr sexp_opaque
 ] [@@deriving sexp]
 
 type tls_server_key = [
@@ -311,6 +312,8 @@ let serve ?backlog ?timeout ?stop
   |`Vchan_direct _ -> Lwt.fail_with "Vchan_direct not implemented"
   | `Vchan_domain_socket _uuid ->
     Lwt.fail_with "Vchan_domain_socket not implemented"
+  | `Listening_socket s ->
+    Sockaddr_server.init ~on:(`Socket s) ?timeout ?stop callback
   | `Launchd name ->
     let fn s = Sockaddr_server.init ~on:(`Socket s) ?timeout ?stop callback in
     Conduit_lwt_launchd.activate fn name

--- a/lwt-unix/conduit_lwt_unix.mli
+++ b/lwt-unix/conduit_lwt_unix.mli
@@ -80,6 +80,7 @@ type server_tls_config =
    - [`Unix_domain_socket (`File path)]: Use UNIX domain sockets to listen on the path.
    - [`Vchan_direct (domid, port)]: Listen for the remote VM on the [domid], [port] tuple.
    - [`Vchan_domain_socket (domain, port_name)]: Use the Vchan name resolution to listen
+   - [`Listening_socket fd]: Use the socket given, useful for inherited systemd sockets.
    - [`Launchd name]: uses MacOS X launchd to start the service, via the name
      of the [Sockets] element within the service description plist file.  See the
      {{:http://mirage.github.io/ocaml-launchd/launchd/}ocaml-launchd} documentation for more.
@@ -90,6 +91,7 @@ type server = [
   | `TLS_native of server_tls_config
   | `TCP of [ `Port of int ]
   | `Unix_domain_socket of [ `File of string ]
+  | `Listening_socket of Lwt_unix.file_descr
   | `Vchan_direct of int * string
   | `Vchan_domain_socket of string  * string
   | `Launchd of string


### PR DESCRIPTION
Fixes #281 . The variant had to be of type `sexp_opaque` because `file_descr` is abstract. That would cause a runtime error trying to serialize one of these, but I assume it won't break other variants.

(network buffs: is "listening socket" the right description for an inherited systemd socket? AFAIK you don't need to call `listen` but you do need to call `accept` on such a socket, so it sounds right to me)