### PR TITLE
Always close channels after handling an event

### DIFF
--- a/lwt-unix/conduit_lwt_unix.ml
+++ b/lwt-unix/conduit_lwt_unix.ml
@@ -187,7 +187,9 @@ module Sockaddr_server = struct
     let events = match timeout with
       |None -> [c]
       |Some t -> [c; (Lwt_unix.sleep (float_of_int t)) ] in
-    Lwt.pick events >>= (fun () -> Conduit_lwt_server.close (ic,oc))
+    Lwt.finalize
+      (fun () -> Lwt.pick events)
+      (fun () -> Conduit_lwt_server.close (ic,oc))
 
   let init ~on ?stop ?backlog ?timeout callback =
     (match on with


### PR DESCRIPTION
In the original expression, if`events` resolves to a failed promise then `ic` and `oc` would not be closed.

Wrapping the whole thing in `Lwt.finalize` should ensure that the input and output channel are always closed properly.  I found this while trying to track down a memory/resource leak.

This issue/patch may be related to https://github.com/mirage/ocaml-cohttp/issues/545