### PR TITLE
conduit-async, mirage-conduit: direct dependency on ipaddr

### DIFF
--- a/conduit-async.opam
+++ b/conduit-async.opam
@@ -15,6 +15,7 @@ depends: [
   "sexplib"
   "conduit"
   "async" {>= "v0.10.0"}
+  "ipaddr" {>= "3.0.0"}
 ]
 depopts: ["async_ssl"]
 conflicts: [

--- a/mirage-conduit.opam
+++ b/mirage-conduit.opam
@@ -19,6 +19,7 @@ depends: [
   "vchan" {>= "3.0.0"}
   "xenstore"
   "tls" {>= "0.8.0"}
+  "ipaddr" {>= "3.0.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}


### PR DESCRIPTION
as discussed in https://github.com/ocaml/opam-repository/pull/13232