### PR TITLE
Addr of uri

### DIFF
--- a/async/conduit_async.ml
+++ b/async/conduit_async.ml
@@ -17,6 +17,7 @@
 
 module V1 = V1
 module V2 = V2
+module V3 = V3
 
 [@@@deprecated "Use Conduit_async.V1"]
 include V1.Conduit_async

--- a/async/dune
+++ b/async/dune
@@ -1,10 +1,10 @@
 (library
  (name        conduit_async)
  (public_name conduit-async)
- (modules     conduit_async private_ssl v1 v2 s)
- (preprocess  (pps ppx_sexp_conv))
+ (modules     conduit_async private_ssl v1 v2 v3 s)
+ (preprocess  (pps ppx_here ppx_sexp_conv))
  (libraries
-   conduit async
+   conduit async ipaddr.unix uri.services
 
     (select private_ssl.ml from
      (async_ssl  -> private_ssl_real.ml)
@@ -16,4 +16,8 @@
 
     (select v2.mli from
      (async_ssl  -> v2_real.mli)
-     (!async_ssl -> v2_dummy.mli))))
+     (!async_ssl -> v2_dummy.mli))
+
+    (select v3.mli from
+     (async_ssl  -> v3_real.mli)
+     (!async_ssl -> v3_dummy.mli))))

--- a/async/s.ml
+++ b/async/s.ml
@@ -171,3 +171,112 @@ module type V2 = sig
     ('a -> Reader.t -> Writer.t -> unit Deferred.t) ->
     ('a, 'b) Tcp.Server.t Deferred.t
 end
+
+module type V3 = sig
+  type allowed_ciphers =
+    [ `Only of string list | `Openssl_default | `Secure ]
+  [@@deriving sexp]
+  type ssl_version [@@deriving sexp]
+  type session [@@deriving sexp_of]
+  type verify_mode [@@deriving sexp_of]
+  type ssl_opt [@@deriving sexp]
+  type ssl_conn [@@deriving sexp_of]
+
+
+  module Ssl : sig
+    module Config : sig
+      type t [@@deriving sexp_of]
+
+      val create
+        : ?version:ssl_version
+        -> ?options:ssl_opt list
+        -> ?name:string
+        -> ?hostname:string
+        -> ?allowed_ciphers:allowed_ciphers
+        -> ?ca_file:string
+        -> ?ca_path:string
+        -> ?crt_file:string
+        -> ?key_file:string
+        -> ?session:session
+        -> ?verify_modes:verify_mode list
+        -> ?verify:(ssl_conn -> bool Deferred.t)
+        -> unit
+        -> t
+    end
+  end
+
+  type _ addr =
+    | OpenSSL : Socket.Address.Inet.t * Ssl.Config.t -> Socket.Address.Inet.t addr
+    | Inet : Socket.Address.Inet.t -> Socket.Address.Inet.t addr
+    | Unix : Socket.Address.Unix.t -> Socket.Address.Unix.t addr
+  [@@deriving sexp_of]
+
+  type _ tcp_sock =
+    | Inet_sock :
+        ([`Active], Socket.Address.Inet.t) Socket.t ->
+        Socket.Address.Inet.t tcp_sock
+    | Unix_sock :
+        ([`Active], Socket.Address.Unix.t) Socket.t ->
+        Socket.Address.Unix.t tcp_sock
+
+  val resolve_uri :
+    ?options:Unix.Addr_info.getaddrinfo_option list -> Uri.t ->
+    Socket.Address.Inet.t addr Deferred.t
+
+  val connect
+    : ?interrupt:unit Deferred.t
+    -> 'a addr
+    -> ('a tcp_sock * Reader.t * Writer.t) Deferred.t
+
+  val with_connection
+    : ?interrupt:unit Deferred.t
+    -> 'a addr
+    -> ('a tcp_sock -> Reader.t -> Writer.t -> 'b Deferred.t)
+    -> 'b Deferred.t
+
+  val connect_uri :
+    ?options:Unix.Addr_info.getaddrinfo_option list ->
+    ?interrupt:unit Deferred.t
+    -> Uri.t
+    -> (Socket.Address.Inet.t tcp_sock * Reader.t * Writer.t) Deferred.t
+
+  val with_connection_uri :
+    ?options:Unix.Addr_info.getaddrinfo_option list ->
+    ?interrupt:unit Deferred.t
+    -> Uri.t
+    -> (Socket.Address.Inet.t tcp_sock -> Reader.t -> Writer.t -> 'a Deferred.t)
+    -> 'a Deferred.t
+
+  type trust_chain =
+    [ `Ca_file of string
+    | `Ca_path of string
+    | `Search_file_first_then_path of
+        [ `File of string ] *
+        [ `Path of string ]
+    ] [@@deriving sexp]
+
+  type openssl =
+    [ `OpenSSL of
+        [ `Crt_file_path of string ] *
+        [ `Key_file_path of string ]
+    ] [@@deriving sexp]
+
+  type server = [
+    | openssl
+    | `TCP
+    | `OpenSSL_with_trust_chain of
+        (openssl * trust_chain)
+  ] [@@deriving sexp]
+
+  val serve :
+    ?max_connections:int ->
+    ?backlog:int ->
+    ?buffer_age_limit:Writer.buffer_age_limit ->
+    on_handler_error:[ `Call of ([< Socket.Address.t ] as 'a) -> exn -> unit
+                     | `Ignore
+                     | `Raise ] ->
+    server ->
+    ('a, 'b) Tcp.Where_to_listen.t ->
+    ('a -> Reader.t -> Writer.t -> unit Deferred.t) ->
+    ('a, 'b) Tcp.Server.t Deferred.t
+end

--- a/async/v3.ml
+++ b/async/v3.ml
@@ -1,0 +1,161 @@
+open Core
+open Async
+open Private_ssl.V2
+
+type _ addr =
+  | OpenSSL : Socket.Address.Inet.t * Ssl.Config.t -> Socket.Address.Inet.t addr
+  | Inet : Socket.Address.Inet.t -> Socket.Address.Inet.t addr
+  | Unix : Socket.Address.Unix.t -> Socket.Address.Unix.t addr
+[@@deriving sexp_of]
+
+type _ tcp_sock =
+  | Inet_sock :
+      ([`Active], Socket.Address.Inet.t) Socket.t ->
+      Socket.Address.Inet.t tcp_sock
+  | Unix_sock :
+      ([`Active], Socket.Address.Unix.t) Socket.t ->
+      Socket.Address.Unix.t tcp_sock
+
+let ssl_schemes = [
+  "https" ;
+  "wss"
+]
+
+let mem_scheme s =
+  List.mem ssl_schemes ~equal:String.equal s
+
+let resolve_uri ?(options=[]) uri =
+  let host =
+    Option.value_exn
+      ~here:[%here]
+      ~message:"no host in URL" (Uri.host uri) in
+  let service =
+    match Uri.port uri, Uri_services.tcp_port_of_uri uri with
+    | Some p, _ -> Some (string_of_int p)
+    | None, Some p -> Some (string_of_int p)
+    | _ -> None in
+  (* Async_extra does not yet support IPv6 *)
+  let options = (Unix.Addr_info.AI_FAMILY PF_INET) :: options in
+  Unix.Addr_info.get ~host ?service options >>= function
+  | [] ->
+    failwithf "unable to resolve %s" (Uri.to_string uri) ()
+  | { ai_addr; _ } :: _ ->
+    match Uri.scheme uri, ai_addr with
+    | _, ADDR_UNIX _ ->
+      invalid_arg "uri must resolve to inet address"
+    | Some s, (ADDR_INET (h, p)) when mem_scheme s ->
+      return (OpenSSL ((`Inet (h, p)), Ssl.Config.create ()))
+    | _, ADDR_INET (h, p) ->
+      return (Inet (`Inet (h, p)))
+
+let connect (type a) ?interrupt (addr: a addr) :
+  (a tcp_sock * Reader.t * Writer.t) Deferred.t =
+  match addr with
+  | Inet addr ->
+    Tcp.connect ?interrupt (Tcp.Where_to_connect.of_inet_address addr)
+    >>| fun (s, r, w) -> (Inet_sock s, r, w)
+  | OpenSSL (addr, cfg) ->
+    Tcp.connect ?interrupt (Tcp.Where_to_connect.of_inet_address addr)
+    >>= fun (s, rd, wr) -> Ssl.connect ~cfg rd wr >>| fun (rd, wr) ->
+    (Inet_sock s, rd, wr)
+  | Unix addr ->
+    Tcp.connect ?interrupt (Tcp.Where_to_connect.of_unix_address addr)
+    >>| fun (s, r, w) -> (Unix_sock s, r, w)
+
+let with_connection (type a) ?interrupt (addr: a addr)
+    (f : a tcp_sock -> Reader.t -> Writer.t -> 'a Deferred.t) =
+  match addr with
+  | Inet addr ->
+    Tcp.with_connection ?interrupt
+      (Tcp.Where_to_connect.of_inet_address addr)
+      (fun s rd wr -> f (Inet_sock s) rd wr)
+  | OpenSSL (addr, cfg) ->
+    Tcp.with_connection ?interrupt
+      (Tcp.Where_to_connect.of_inet_address addr)
+      begin fun s rd wr ->
+        Ssl.connect ~cfg rd wr >>= fun (rd, wr) ->
+        Monitor.protect (fun () -> f (Inet_sock s) rd wr) ~finally:begin fun () ->
+          Deferred.all_unit [ Reader.close rd ; Writer.close wr ]
+        end
+      end
+  | Unix addr ->
+    Tcp.with_connection ?interrupt (Tcp.Where_to_connect.of_unix_address addr)
+      (fun s rd wr -> f (Unix_sock s) rd wr)
+
+let connect_uri ?options ?interrupt uri =
+  resolve_uri ?options uri >>= fun addr ->
+  connect ?interrupt addr
+
+let with_connection_uri ?options ?interrupt uri f =
+  resolve_uri ?options uri >>= fun addr ->
+  with_connection ?interrupt addr f
+
+type trust_chain = [
+  | `Ca_file of string
+  | `Ca_path of string
+  | `Search_file_first_then_path of
+      [ `File of string ] *
+      [ `Path of string ]
+] [@@deriving sexp]
+
+type openssl = [
+  | `OpenSSL of
+      [ `Crt_file_path of string ] *
+      [ `Key_file_path of string ]
+] [@@deriving sexp]
+
+type requires_async_ssl = [
+  | openssl
+  | `OpenSSL_with_trust_chain of openssl * trust_chain
+] [@@deriving sexp]
+
+type server = [
+  | `TCP
+  | requires_async_ssl
+] [@@deriving sexp]
+
+let serve
+    ?max_connections ?backlog
+    ?buffer_age_limit ~on_handler_error mode where_to_listen handle_request =
+  let handle_client handle_request sock rd wr =
+    match mode with
+    | `TCP -> handle_request sock rd wr
+    | #requires_async_ssl as async_ssl ->
+      let (crt_file, key_file, ca_file, ca_path) =
+        match async_ssl with
+        | `OpenSSL (`Crt_file_path crt_file, `Key_file_path key_file) ->
+          (crt_file, key_file, None, None)
+        | `OpenSSL_with_trust_chain
+            (`OpenSSL (`Crt_file_path crt, `Key_file_path key), trust_chain) ->
+          let (ca_file, ca_path) =
+            match trust_chain with
+            | `Ca_file ca_file -> (Some ca_file, None)
+            | `Ca_path ca_path -> (None, Some ca_path)
+            | `Search_file_first_then_path (`File ca_file, `Path ca_path) ->
+              (Some ca_file, Some ca_path)
+          in
+          (crt, key, ca_file, ca_path)
+      in
+      let cfg = Ssl.Config.create
+          ?ca_file ?ca_path ~crt_file ~key_file () in
+      Ssl.listen cfg rd wr >>= fun (rd,wr) ->
+      Monitor.protect
+        (fun () -> handle_request sock rd wr)
+        ~finally:(fun () ->
+            Deferred.all_unit [ Reader.close rd ; Writer.close wr ])
+  in
+  Tcp.Server.create ?max_connections ?backlog
+    ?buffer_age_limit ~on_handler_error
+    where_to_listen (handle_client handle_request)
+
+type ssl_version = Ssl.version [@@deriving sexp]
+type ssl_opt = Ssl.opt [@@deriving sexp]
+type ssl_conn = Ssl.connection [@@deriving sexp_of]
+type allowed_ciphers =
+  [ `Only of string list | `Openssl_default | `Secure ]
+[@@deriving sexp]
+type verify_mode = Ssl.verify_mode [@@deriving sexp_of]
+type session = Ssl.session [@@deriving sexp_of]
+module Ssl = struct
+  module Config = Ssl.Config
+end

--- a/async/v3_dummy.mli
+++ b/async/v3_dummy.mli
@@ -1,0 +1,8 @@
+include S.V3
+  with type session = [`Ssl_not_compiled_in]
+   and type ssl_version = [`Ssl_not_compiled_in]
+   and type ssl_conn = [`Ssl_not_compiled_in]
+   and type ssl_opt = [`Ssl_not_compiled_in]
+   and type allowed_ciphers =
+         [ `Only of string list | `Openssl_default | `Secure ]
+

--- a/async/v3_real.mli
+++ b/async/v3_real.mli
@@ -1,0 +1,8 @@
+open Async_ssl
+include S.V3
+  with type session = Ssl.Session.t
+   and type ssl_version = Ssl.Version.t
+   and type ssl_conn = Ssl.Connection.t
+   and type ssl_opt = Ssl.Opt.t
+   and type allowed_ciphers =
+         [ `Only of string list | `Openssl_default | `Secure ]

--- a/mirage/dune
+++ b/mirage/dune
@@ -4,6 +4,7 @@
   (preprocess  (pps ppx_sexp_conv))
   (modules     conduit_mirage resolver_mirage conduit_xenstore)
   (wrapped     false)
+  (optional)
   (libraries   conduit conduit-lwt mirage-stack-lwt mirage-time-lwt
                mirage-flow-lwt mirage-dns ipaddr.sexp
                vchan tls tls.mirage xenstore.client))


### PR DESCRIPTION
This adds a convenience function to resolve `Uri.t` into an `addr` as used by `conduit-async`.