### PR TITLE
conduit-lwt-unix: Only close fd once

### DIFF
--- a/lwt-unix/conduit_lwt_unix.ml
+++ b/lwt-unix/conduit_lwt_unix.ml
@@ -160,6 +160,33 @@ let init ?src ?(tls_server_key=`None) () =
     | {ai_addr;_}::_ -> Lwt.return { src=Some ai_addr; tls_server_key }
     | [] -> Lwt.fail_with "Invalid conduit source address specified"
 
+module Sockaddr_io = struct
+  let shutdown_no_exn fd mode =
+    try Lwt_unix.shutdown fd mode
+    with Unix.Unix_error (Unix.ENOTCONN, _, _) -> ()
+
+  let make_fd_state () =
+    ref `Open
+
+  let make fd =
+    let fd_state = make_fd_state () in
+    let close_in () =
+      match !fd_state with
+      | `Open -> fd_state := `In_closed; shutdown_no_exn fd Unix.SHUTDOWN_RECEIVE; Lwt.return_unit
+      | `Out_closed -> fd_state := `Closed; Lwt_unix.close fd
+      | `In_closed (* repeating on a closed channel is a noop in Lwt_io *)
+      | `Closed -> Lwt.return_unit  in
+    let close_out () =
+      match !fd_state with
+      | `Open -> fd_state := `Out_closed; shutdown_no_exn fd Unix.SHUTDOWN_SEND; Lwt.return_unit
+      | `In_closed -> fd_state := `Closed; Lwt_unix.close fd
+      | `Out_closed (* repeating on a closed channel is a noop in Lwt_io *)
+      | `Closed -> Lwt.return_unit  in
+    let ic = Lwt_io.of_fd ~close:close_in  ~mode:Lwt_io.input fd in
+    let oc = Lwt_io.of_fd ~close:close_out ~mode:Lwt_io.output fd in
+    (ic, oc)
+end
+
 (* Vanilla sockaddr connection *)
 module Sockaddr_client = struct
   let connect ?src sa =
@@ -167,16 +194,13 @@ module Sockaddr_client = struct
         (match src with
          | None -> Lwt.return_unit
          | Some src_sa -> Lwt_unix.bind fd src_sa) >>= fun () ->
-        Lwt_io.open_connection ~fd sa >>= fun (ic, oc) ->
+        Lwt_unix.connect fd sa >>= fun () ->
+        let ic, oc = Sockaddr_io.make fd in
         Lwt.return (fd, ic, oc)
       )
 end
 
 module Sockaddr_server = struct
-
-  let shutdown_no_exn fd mode =
-    try Lwt_unix.shutdown fd mode
-    with Unix.Unix_error (Unix.ENOTCONN, _, _) -> ()
 
   let set_sockopts_no_exn fd =
     try Lwt_unix.setsockopt fd Lwt_unix.TCP_NODELAY true
@@ -185,21 +209,7 @@ module Sockaddr_server = struct
 
   let process_accept ?timeout callback (client,peeraddr) =
     set_sockopts_no_exn client;
-    let fd_state = ref `Open in
-    let close_in () =
-      match !fd_state with
-      | `Open -> fd_state := `In_closed; shutdown_no_exn client Unix.SHUTDOWN_RECEIVE; Lwt.return_unit
-      | `Out_closed -> fd_state := `Closed; Lwt_unix.close client
-      | `In_closed (* repeating on a closed channel is a noop in Lwt_io *)
-      | `Closed -> Lwt.return_unit  in
-     let close_out () =
-      match !fd_state with
-      | `Open -> fd_state := `Out_closed; shutdown_no_exn client Unix.SHUTDOWN_SEND; Lwt.return_unit
-      | `In_closed -> fd_state := `Closed; Lwt_unix.close client
-      | `Out_closed (* repeating on a closed channel is a noop in Lwt_io *)
-      | `Closed -> Lwt.return_unit  in
-    let ic = Lwt_io.of_fd ~close:close_in  ~mode:Lwt_io.input client in
-    let oc = Lwt_io.of_fd ~close:close_out ~mode:Lwt_io.output client in
+    let ic, oc = Sockaddr_io.make client in
     let c = callback (flow_of_fd client peeraddr) ic oc in
     let events = match timeout with
       |None -> [c]

--- a/lwt-unix/conduit_lwt_unix.ml
+++ b/lwt-unix/conduit_lwt_unix.ml
@@ -167,9 +167,7 @@ module Sockaddr_client = struct
         (match src with
          | None -> Lwt.return_unit
          | Some src_sa -> Lwt_unix.bind fd src_sa) >>= fun () ->
-        Lwt_unix.connect fd sa >>= fun () ->
-        let ic = Lwt_io.of_fd ~mode:Lwt_io.input fd in
-        let oc = Lwt_io.of_fd ~mode:Lwt_io.output fd in
+        Lwt_io.open_connection ~fd sa >>= fun (ic, oc) ->
         Lwt.return (fd, ic, oc)
       )
 end
@@ -181,8 +179,11 @@ module Sockaddr_server = struct
      with
      (* This is expected for Unix domain sockets *)
      | Unix.Unix_error(Unix.EOPNOTSUPP, _, _) -> ());
-    let ic = Lwt_io.of_fd ~mode:Lwt_io.input client in
-    let oc = Lwt_io.of_fd ~mode:Lwt_io.output client in
+    (* We only want to close the client fd once *)
+    let close_fd = lazy (Lwt_unix.close client) in
+    let close () = Lazy.force close_fd in
+    let ic = Lwt_io.of_fd ~close ~mode:Lwt_io.input client in
+    let oc = Lwt_io.of_fd ~close ~mode:Lwt_io.output client in
     let c = callback (flow_of_fd client peeraddr) ic oc in
     let events = match timeout with
       |None -> [c]

--- a/lwt-unix/conduit_lwt_unix_ssl_real.ml
+++ b/lwt-unix/conduit_lwt_unix_ssl_real.ml
@@ -20,8 +20,9 @@ open Lwt.Infix
 let () = Ssl.init ()
 
 let chans_of_fd sock =
-  let shutdown () = Lwt_ssl.ssl_shutdown sock in
-  let close () = Lwt_ssl.close sock in
+  let is_open = ref true in
+  let shutdown () = if !is_open then Lwt_ssl.ssl_shutdown sock else Lwt.return_unit in
+  let close () = is_open := false; Lwt_ssl.close sock in
   let oc = Lwt_io.make ~mode:Lwt_io.output ~close:shutdown (Lwt_ssl.write_bytes sock) in
   let ic = Lwt_io.make ~mode:Lwt_io.input ~close (Lwt_ssl.read_bytes sock) in
   ((Lwt_ssl.get_fd sock), ic, oc)


### PR DESCRIPTION
Use Lwt_io.open_connection to create (ic, oc) for client connections,
and only close server's client fd once with a custom close function.

The `lazy` close idea comes from `Lwt_io.open_connection`.