### PR TITLE
[WIP] ssh client support in conduit_mirage

### DIFF
--- a/conduit-mirage.opam
+++ b/conduit-mirage.opam
@@ -25,6 +25,7 @@ depends: [
   "tls-mirage" {>= "0.11.0"}
   "ipaddr" {>= "3.0.0"}
   "ipaddr-sexp"
+  "awa-mirage"
 ]
 conflicts: [
   "mirage-conduit"

--- a/lib/conduit.ml
+++ b/lib/conduit.ml
@@ -25,6 +25,7 @@ type endp = [
   | `Vchan_direct of int * string        (** domain id, port *)
   | `Vchan_domain_socket of string * string
   | `TLS of string * endp         (** wrap in a TLS channel, [hostname,endp] *)
+  | `SSH of Ipaddr_sexp.t * int * string option
   | `Unknown of string            (** failed resolution *)
 ] [@@deriving sexp]
 

--- a/lib/conduit.mli
+++ b/lib/conduit.mli
@@ -55,6 +55,7 @@ type endp = [
   | `Vchan_direct of int * string  (** domain id, port *)
   | `Vchan_domain_socket of string * string (** Vchan Xen domain socket *)
   | `TLS of string * endp          (** Wrap in a TLS channel, [hostname,endp] *)
+  | `SSH of Ipaddr.t * int * string option
   | `Unknown of string             (** Failed resolution *)
 ] [@@deriving sexp]
 

--- a/lwt-unix/conduit_lwt_unix.ml
+++ b/lwt-unix/conduit_lwt_unix.ml
@@ -401,6 +401,7 @@ let endp_to_client ~ctx:_ (endp:Conduit.endp) : client Lwt.t =
                        host (Sexplib.Sexp.to_string_hum (Conduit.sexp_of_endp endp)))
     end
   | `Unknown err -> Lwt.fail_with ("resolution failed: " ^ err)
+  | _ -> assert false
 
 let endp_to_server ~ctx (endp:Conduit.endp) =
   match endp with
@@ -417,3 +418,4 @@ let endp_to_server ~ctx (endp:Conduit.endp) =
   | `Vchan_domain_socket _ as mode -> Lwt.return mode
   | `TLS (_host, _) -> Lwt.fail_with "TLS to non-TCP currently unsupported"
   | `Unknown err -> Lwt.fail_with ("resolution failed: " ^ err)
+  | _ -> assert false

--- a/mirage/conduit_mirage.mli
+++ b/mirage/conduit_mirage.mli
@@ -79,18 +79,21 @@ type xs
 val vchan: (module VCHAN) -> vchan
 val xs: (module XS) -> xs
 
+type ssh_client = [ `SSH of Ipaddr_sexp.t * int * string * string ]
+type ssh_server = [ `SSH of unit ]
+
 (** {2 TLS} *)
 
 type 'a tls_client = [ `TLS of Tls.Config.client * 'a ]
 type 'a tls_server = [ `TLS of Tls.Config.server * 'a ]
 
-type client = [ tcp_client | vchan_client | client tls_client ] [@@deriving sexp]
+type client = [ tcp_client | vchan_client | client tls_client | ssh_client ] [@@deriving sexp]
 (** The type for client configuration values. *)
 
-type server = [ tcp_server | vchan_server | server tls_server ] [@@deriving sexp]
+type server = [ tcp_server | vchan_server | server tls_server | ssh_server ] [@@deriving sexp]
 (** The type for server configuration values. *)
 
-val client: Conduit.endp -> client Lwt.t
+val client: ?config:string -> Conduit.endp -> client Lwt.t
 (** Resolve a conduit endpoint into a client configuration. *)
 
 val server: Conduit.endp -> server Lwt.t
@@ -116,6 +119,9 @@ module type S = sig
 
   val with_tls: t -> t Lwt.t
   (** Extend a conduit with an implementation for TLS. *)
+
+  val with_ssh: t -> (module Mirage_clock.MCLOCK) -> t Lwt.t
+  (** Extend a conduit with an implementation for SSH. *)
 
   val with_vchan: t -> xs -> vchan -> string -> t Lwt.t
   (** Extend a conduit with an implementation for VCHAN. *)

--- a/mirage/dune
+++ b/mirage/dune
@@ -6,4 +6,4 @@
   (wrapped     false)
   (libraries   conduit conduit-lwt mirage-stack mirage-clock mirage-random mirage-time
                mirage-flow mirage-flow-combinators dns-client.mirage ipaddr-sexp
-               vchan tls tls-mirage xenstore.client uri.services))
+               vchan tls tls-mirage xenstore.client uri.services awa-mirage))

--- a/mirage/resolver_mirage.ml
+++ b/mirage/resolver_mirage.ml
@@ -100,7 +100,12 @@ module Make_with_stack (R: Mirage_random.S) (T : Mirage_time.S) (C: Mirage_clock
            | Error (`Msg msg) -> Lwt.return (Error (`Msg msg))
            | Ok host -> DNS.gethostbyname dns host) >|= function
       | Error (`Msg err) -> `Unknown ("name resolution failed: " ^ err)
-      | Ok addr -> `TCP (Ipaddr.V4 addr, port)
+      | Ok addr ->
+        match service.Resolver.name with
+        | "ssh" ->
+          let user = Uri.user uri in
+          `SSH (Ipaddr.V4 addr, port, user)
+        | _ -> `TCP (Ipaddr.V4 addr, port)
 
     let register ?ns ?(ns_port = 53) ?stack res =
       begin match stack with


### PR DESCRIPTION
please do not merge as is, this is on top of #290 (in this PR, only 5f1f30f is relevant)

the abstraction provided by conduit (`client`), loosely speaking: given an Uri.t provide a flow (with read/write/close) is not sufficient for ssh (FWIW, same is true for tls):
- ssh needs (well, certainly you can use a password if you like) a private key for authentication, as well as an authenticator (usually a server fingerprint, but maybe as well a CA certificate), and a command to execute (this is not talking about the fully general ssh protocol, just the bits needed for git+ssh)
- tls should accept an authenticator as well, also an optional client certificate

it is not clear to me how this fits / should fit into conduit:
- atm i used an optional `string`(`?config`) and serialise/deserialise the command, private key seed, and authenticator -- this should be slightly better typed (sth like a ssh config)
- unclear whether conduit should depend on the Tls.Config.client and Awa.Client.client directly or provide other structures

--> it is as well a bit unclear whether the goal of conduit is to be extensible in terms of transport protocols (i.e. should there be a conduit-mirage-tls, conduit-mirage-ssh)?