### PR TITLE
Expose verify_mode in Conduit_async

### DIFF
--- a/async/v2_real.mli
+++ b/async/v2_real.mli
@@ -4,5 +4,6 @@ include S.V2
    and type ssl_version = Ssl.Version.t
    and type ssl_conn = Ssl.Connection.t
    and type ssl_opt = Ssl.Opt.t
+   and type verify_mode = Ssl.Verify_mode.t
    and type allowed_ciphers =
          [ `Only of string list | `Openssl_default | `Secure ]

--- a/async/v3_real.mli
+++ b/async/v3_real.mli
@@ -4,5 +4,6 @@ include S.V3
    and type ssl_version = Ssl.Version.t
    and type ssl_conn = Ssl.Connection.t
    and type ssl_opt = Ssl.Opt.t
+   and type verify_mode = Ssl.Verify_mode.t
    and type allowed_ciphers =
          [ `Only of string list | `Openssl_default | `Secure ]


### PR DESCRIPTION
Previously the verify_mode was private, which made it impossible
to turn on certificate verification.