### PR TITLE
replace the dune/ocaml file with a `(select)` build form.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
    - PINS="conduit:. mirage-conduit:. conduit-async:. conduit-lwt:. conduit-lwt-unix:."
    - TESTS=true
  matrix:
+   - OCAML_VERSION=4.08 PACKAGE=conduit-lwt-unix DISTRO=debian-stable   DEPOPTS="ssl tls"
    - OCAML_VERSION=4.07 PACKAGE=conduit-lwt-unix DISTRO=debian-stable   DEPOPTS="ssl tls"
    - OCAML_VERSION=4.06 PACKAGE=conduit-lwt-unix DISTRO=debian-unstable DEPOPTS="ssl tls"
    - OCAML_VERSION=4.05 PACKAGE=conduit-async    DISTRO=debian-unstable DEPOPTS=async_ssl

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## dev
+
+* lwt-unix: replace the dune/ocaml file with a `(select)` build form.
+  This avoids invoking `ocamlfind` from the build, and fits in with the
+  rest of dune builds much more naturally (@avsm).
+
 ## v1.5.0
 
 * lwt-unix: Do not close file descriptors more than once, which led to a lot of

--- a/lwt-unix/dune
+++ b/lwt-unix/dune
@@ -1,25 +1,3 @@
-(* -*- tuareg -*- *)
-
-let v ~launchd ~ssl ~tls () =
-  let launchd, launchd_d =
-    if launchd then "conduit_lwt_launchd_real", "launchd.lwt "
-    else "conduit_lwt_launchd_dummy", ""
-  in
-  let ssl, ssl_d =
-    if ssl then "conduit_lwt_unix_ssl_real", "lwt_ssl "
-    else "conduit_lwt_unix_ssl_dummy", ""
-  in
-  let tls, tls_d =
-    if tls then "conduit_lwt_tls_real", "tls.lwt "
-    else "conduit_lwt_tls_dummy", ""
-  in
-  Printf.sprintf {|
-(rule (copy %s.ml conduit_lwt_launchd.ml))
-(rule (copy %s.ml conduit_lwt_unix_ssl.ml))
-(rule (copy %s.ml conduit_lwt_tls.ml))
-(rule (copy %s.mli conduit_lwt_unix_ssl.mli))
-(rule (copy %s.mli conduit_lwt_tls.mli))
-
 (library
   (name        conduit_lwt_unix)
   (public_name conduit-lwt-unix)
@@ -27,20 +5,14 @@ let v ~launchd ~ssl ~tls () =
   (wrapped     false)
   (modules     resolver_lwt_unix conduit_lwt_unix conduit_lwt_server
                conduit_lwt_tls conduit_lwt_unix_ssl conduit_lwt_launchd)
-  (libraries   conduit-lwt lwt.unix uri.services ipaddr-sexp ipaddr.unix logs %s%s%s))
-|} launchd ssl tls ssl tls launchd_d ssl_d tls_d
-
-let main () =
-  let is_installed s = Printf.kprintf Sys.command "ocamlfind query %s" s = 0 in
-  let launchd = is_installed "launchd.lwt" in
-  let ssl = is_installed "lwt_ssl" in
-  let tls = Sys.unix && is_installed "tls.lwt" in
-  Printf.printf
-    "Configuration\n\
-    \  launchd: %b\n\
-    \  ssl    : %b\n\
-    \  tls    : %b\n%!"
-    launchd ssl tls;
-  v ~launchd ~ssl ~tls ()
-
-let () = Jbuild_plugin.V1.send @@ main ()
+  (libraries   conduit-lwt lwt.unix uri.services ipaddr-sexp ipaddr.unix logs
+    (select conduit_lwt_launchd.ml from
+      (launchd.lwt -> conduit_lwt_launchd_real.ml)
+      (-> conduit_lwt_launchd_dummy.ml))
+    (select conduit_lwt_unix_ssl.ml from
+      (lwt_ssl -> conduit_lwt_unix_ssl_real.ml)
+      (-> conduit_lwt_unix_ssl_dummy.ml))
+    (select conduit_lwt_tls.ml from
+      (tls.lwt -> conduit_lwt_tls_real.ml)
+      (-> conduit_lwt_tls_dummy.ml))
+  ))


### PR DESCRIPTION
This avoids invoking `ocamlfind` from the build, and fits in with the
rest of dune builds much more naturally (@avsm).

Also add 4.08 to the testing matrix.