### PR TITLE
fix merge error that causes Lwt_ssl compilation to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,13 @@ env:
    - PINS="conduit:. conduit-mirage:. conduit-async:. conduit-lwt:. conduit-lwt-unix:."
    - TESTS=true
  matrix:
-   - OCAML_VERSION=4.08 PACKAGE=conduit-lwt-unix DISTRO=debian-stable   DEPOPTS="ssl tls"
+   - OCAML_VERSION=4.08 PACKAGE=conduit-lwt-unix DISTRO=debian-stable   DEPOPTS="lwt_ssl tls"
    - OCAML_VERSION=4.07 PACKAGE=conduit-mirage   DISTRO=alpine
-   - OCAML_VERSION=4.07 PACKAGE=conduit-lwt-unix DISTRO=debian-stable   DEPOPTS="ssl tls"
-   - OCAML_VERSION=4.06 PACKAGE=conduit-lwt-unix DISTRO=debian-unstable DEPOPTS="ssl tls"
+   - OCAML_VERSION=4.07 PACKAGE=conduit-lwt-unix DISTRO=debian-stable   DEPOPTS="lwt_ssl tls"
+   - OCAML_VERSION=4.06 PACKAGE=conduit-lwt-unix DISTRO=debian-unstable DEPOPTS="lwt_ssl tls"
    - OCAML_VERSION=4.05 PACKAGE=conduit-async    DISTRO=debian-unstable DEPOPTS=async_ssl
-   - OCAML_VERSION=4.04 PACKAGE=conduit-lwt-unix DISTRO=debian-testing  DEPOPTS="ssl tls"
+   - OCAML_VERSION=4.04 PACKAGE=conduit-lwt-unix DISTRO=debian-testing  DEPOPTS="lwt_ssl tls"
    - OCAML_VERSION=4.06 PACKAGE=conduit-async    DISTRO=centos          DEPOPTS=async_ssl
-   - OCAML_VERSION=4.06 PACKAGE=conduit-lwt-unix DISTRO=alpine          DEPOPTS="ssl tls"
+   - OCAML_VERSION=4.06 PACKAGE=conduit-lwt-unix DISTRO=alpine          DEPOPTS="lwt_ssl tls"
    - OCAML_VERSION=4.06 PACKAGE=conduit-async    DISTRO=ubuntu          DEPOPTS=async_ssl
-   - OCAML_VERSION=4.06 PACKAGE=conduit-lwt-unix DISTRO=fedora          DEPOPTS="ssl tls"
+   - OCAML_VERSION=4.06 PACKAGE=conduit-lwt-unix DISTRO=fedora          DEPOPTS="lwt_ssl tls"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## v2.0.1
+
+* lwt-unix: fix compilation with `lwt_ssl` and fix tests to correctly exercise this
+  part of the codepath (@avsm).
+
 ## v2.0.0 (2019-08-17)
 
 * lwt-unix: obtain client IP correctly when using TLS connections (#277 @victorgomes)

--- a/lwt-unix/conduit_lwt_unix_ssl_real.ml
+++ b/lwt-unix/conduit_lwt_unix_ssl_real.ml
@@ -32,10 +32,9 @@ module Client = struct
     let ctx = Ssl.create_context Ssl.SSLv23 Ssl.Client_context in
     Ssl.disable_protocols ctx [Ssl.SSLv23];
     (* Use default CA certificates *)
-    ignore (Ssl.set_default_verify_paths default_ctx);
+    ignore (Ssl.set_default_verify_paths ctx);
     (* Enable peer verification *)
-    Ssl.set_verify default_ctx [Ssl.Verify_peer] None
-    ignore (Ssl.set_default_verify_paths default_ctx);
+    Ssl.set_verify ctx [Ssl.Verify_peer] None;
     (match certfile, keyfile with
      | Some certfile, Some keyfile -> Ssl.use_certificate ctx certfile keyfile
      | None, _ | _, None -> ());


### PR DESCRIPTION
This got past tests since since the wrong packages are installed
by the Travis tests. That's also now addressed.