### PR TITLE
update for dns-client 4.5.0 which introduces timeouts for DNS requests

### DIFF
--- a/conduit-mirage.opam
+++ b/conduit-mirage.opam
@@ -16,7 +16,7 @@ depends: [
   "mirage-flow" {>= "2.0.0"}
   "mirage-flow-combinators" {>= "2.0.0"}
   "mirage-random" {>= "2.0.0"}
-  "dns-client" {>= "4.1.0"}
+  "dns-client" {>= "4.5.0"}
   "conduit-lwt"
   "vchan" {>= "5.0.0"}
   "xenstore"

--- a/mirage/conduit_mirage.ml
+++ b/mirage/conduit_mirage.ml
@@ -326,11 +326,11 @@ let rec server (e:Conduit.endp): server Lwt.t = match e with
   | `TLS (x, y) -> server y >>= fun s -> tls_server x s
   | `Unknown s -> err_unknown s
 
-module Context (R: Mirage_random.S) (C: Mirage_clock.MCLOCK) (S: Mirage_stack.V4) = struct
+module Context (R: Mirage_random.S) (T : Mirage_time.S) (C: Mirage_clock.MCLOCK) (S: Mirage_stack.V4) = struct
 
   type t = Resolver_lwt.t * conduit
 
-  module RES = Resolver_mirage.Make_with_stack(R)(C)(S)
+  module RES = Resolver_mirage.Make_with_stack(R)(T)(C)(S)
 
   let conduit = empty
   let stackv4 = stackv4 (module S: Mirage_stack.V4 with type t = S.t)

--- a/mirage/conduit_mirage.mli
+++ b/mirage/conduit_mirage.mli
@@ -131,7 +131,7 @@ end
 include S
 
 (** {2 Context for MirageOS conduit resolvers} *)
-module Context (R: Mirage_random.S) (C: Mirage_clock.MCLOCK) (S: Mirage_stack.V4): sig
+module Context (R: Mirage_random.S) (T : Mirage_time.S) (C: Mirage_clock.MCLOCK) (S: Mirage_stack.V4): sig
 
   type t = Resolver_lwt.t * conduit
   (** The type for contexts of conduit resolvers. *)

--- a/mirage/resolver_mirage.ml
+++ b/mirage/resolver_mirage.ml
@@ -63,7 +63,7 @@ let localhost =
               (fun ~port -> `TCP (Ipaddr.(V4 V4.localhost), port));
   static hosts
 
-module Make_with_stack (R: Mirage_random.S) (C: Mirage_clock.MCLOCK) (S: Mirage_stack.V4) = struct
+module Make_with_stack (R: Mirage_random.S) (T : Mirage_time.S) (C: Mirage_clock.MCLOCK) (S: Mirage_stack.V4) = struct
   include Resolver_lwt
 
   module R = struct
@@ -85,7 +85,7 @@ module Make_with_stack (R: Mirage_random.S) (C: Mirage_clock.MCLOCK) (S: Mirage_
           (Uri.to_string uri) remote_name;
         Lwt.return (`Vchan_domain_socket (remote_name, service.Resolver.name))
 
-    module DNS = Dns_client_mirage.Make(R)(C)(S)
+    module DNS = Dns_client_mirage.Make(R)(T)(C)(S)
 
     let dns_stub_resolver dns service uri : Conduit.endp Lwt.t =
       let hostn = get_host uri in

--- a/mirage/resolver_mirage.mli
+++ b/mirage/resolver_mirage.mli
@@ -29,7 +29,7 @@ val localhost : Resolver_lwt.t
 (** Provides a DNS-enabled {!Resolver_lwt} given a network stack.
     See {!Make}.
 *)
-module Make_with_stack (R: Mirage_random.S) (C: Mirage_clock.MCLOCK) (S: Mirage_stack.V4) : sig
+module Make_with_stack (R: Mirage_random.S) (T : Mirage_time.S) (C: Mirage_clock.MCLOCK) (S: Mirage_stack.V4) : sig
   include Resolver_lwt.S with type t = Resolver_lwt.t
 
   module R : sig


### PR DESCRIPTION
I'm not sure how far #311 is in respect to timeline of being merged (//cc @avsm @dinosaure). if it'll be done this week, please disregard this PR. For MirageOS use, this also requires changes to the mirage tool (since the functor arguments are hardcoded there), which I'll PR soon.