### PR TITLE
fix support for tls 0.12.1 (by not calling Mirage_crypto_rng_unix.initialize, which was a transitive dependency anyways)

### DIFF
--- a/lwt-unix/conduit_lwt_tls_real.ml
+++ b/lwt-unix/conduit_lwt_tls_real.ml
@@ -17,8 +17,6 @@
 
 open Lwt.Infix
 
-let () = Mirage_crypto_rng_unix.initialize ()
-
 module X509 = struct
   let private_of_pems ~cert ~priv_key =
     X509_lwt.private_of_pems ~cert ~priv_key


### PR DESCRIPTION
the application should call the initialize, not the library code (since the call should be inside Lwt_main.run).