### PR TITLE
use close-notify for unidirectional shutdown

### DIFF
--- a/lwt-unix/conduit_lwt_unix_ssl_real.ml
+++ b/lwt-unix/conduit_lwt_unix_ssl_real.ml
@@ -21,7 +21,11 @@ let () = Ssl.init ()
 
 let chans_of_fd sock =
   let is_open = ref true in
-  let shutdown () = if !is_open then Lwt_ssl.ssl_shutdown sock else Lwt.return_unit in
+  let shutdown () =
+    if !is_open
+    then Lwt_ssl.close_notify sock >|= ignore
+    else Lwt.return_unit
+  in
   let close () = is_open := false; Lwt_ssl.close sock in
   let oc = Lwt_io.make ~mode:Lwt_io.output ~close:shutdown (Lwt_ssl.write_bytes sock) in
   let ic = Lwt_io.make ~mode:Lwt_io.input ~close (Lwt_ssl.read_bytes sock) in


### PR DESCRIPTION
ocaml-ssl's shutdown does a full bi-directional shutdown.

one-way shutdown is needed to send `EOF`.

See also https://github.com/ocsigen/lwt_ssl/pull/2 and https://github.com/savonet/ocaml-ssl/pull/63