### PR TITLE
conduit-lwt-unix: require tls 0.12.2+

### DIFF
--- a/conduit-lwt-unix.opam
+++ b/conduit-lwt-unix.opam
@@ -20,7 +20,7 @@ depends: [
 ]
 depopts: ["tls" "lwt_ssl" "launchd"]
 conflicts: [
-  "tls" {< "0.11.0"}
+  "tls" {< "0.12.2"}
   "ssl" {< "0.5.9"}
 ]
 build: [


### PR DESCRIPTION
downstream https://github.com/ocaml/opam-repository/pull/16697 fixes #318