### PR TITLE
conduit-lwt-tls: initialize the mirage-crypto-rng.lwt PRNG

### DIFF
--- a/conduit-lwt-tls.opam
+++ b/conduit-lwt-tls.opam
@@ -25,4 +25,5 @@ depends: [
   "dune"
   "conduit-lwt"
   "conduit-tls"
+  "mirage-crypto-rng" {>= "0.8.0"}
 ]

--- a/src/lwt-tls/conduit_lwt_tls.ml
+++ b/src/lwt-tls/conduit_lwt_tls.ml
@@ -1,5 +1,7 @@
 include Conduit_tls.Make (Conduit_lwt.IO) (Conduit_lwt)
 
+let () = Mirage_crypto_rng_lwt.initialize ()
+
 module TCP = struct
   open Conduit_lwt.TCP
 

--- a/src/lwt-tls/dune
+++ b/src/lwt-tls/dune
@@ -1,4 +1,4 @@
 (library
  (name conduit_lwt_tls)
  (public_name conduit-lwt-tls)
- (libraries conduit-lwt conduit-tls))
+ (libraries conduit-lwt conduit-tls mirage-crypto-rng.lwt))


### PR DESCRIPTION
previously, conduit(-lwt-tls) used tls.lwt which does the RNG initialization. Now, the tls API is directly used, so the conduit-lwt-tls package should initialize the PRNG.