### PR TITLE
Fix use of lwt_io + conduit-tls

### DIFF
--- a/src/lwt/conduit_lwt.ml
+++ b/src/lwt/conduit_lwt.ml
@@ -113,8 +113,28 @@ module TCP = struct
       socket : Lwt_unix.file_descr;
       sockaddr : Lwt_unix.sockaddr;
       linger : Bytes.t;
+      recv_first : bool;
       mutable closed : bool;
     }
+
+    (* XXX(dinosaure): [recv_first] is here to fit into [Lwt_io], from what we know,
+     * a tuple of [Lwt_io] [in_channel/out_channel] tries to receive first. However,
+     * such behavior is problematic for HTTP:
+     * - as a HTTP client, we should send first
+     * - as a HTTP server, we should recv first
+     * - with TLS layer [conduit-tls], both work - where
+     *   the handshake can be done by send or recv
+     *
+     * For my perspective, [Lwt_io] is not the right way to abstract a [Conduit.flow]
+     * and we should directly use [Conduit.send]/[Conduit.recv] when we need to use
+     * them. Because [Lwt_io] tries to receive in any case, we must check (with [Lwt_unix.readable])
+     * if the socket can be read. In that case and if we want to [recv_first], we start
+     * to waiting something from our peer. In the other case, we returns [`Input 0]
+     * which gives an opportunity for the scheduler to send something (so, [send_first]).
+     *
+     * Such patch is really close to what LWT/[Lwt_io] does. A problem should be a diff
+     * on behaviors between [Conduit_lwt] and [mirage-tcpip] + [Conduit_mirage]. The best
+     * way to delete it is to deprecate [io_of_flow]. *)
 
     let peer { sockaddr; _ } = sockaddr
 
@@ -163,7 +183,14 @@ module TCP = struct
       let rec go () =
         let process () =
           Lwt_unix.connect socket sockaddr >>= fun () ->
-          Lwt.return_ok { socket; sockaddr; linger; closed = false } in
+          Lwt.return_ok
+            {
+              socket;
+              sockaddr;
+              linger;
+              closed = false;
+              recv_first = Lwt_unix.readable socket;
+            } in
         Lwt.catch process @@ function
         | Unix.(Unix_error ((EACCES | EPERM), _, _)) ->
             Lwt.return_error `Operation_not_permitted
@@ -223,7 +250,7 @@ module TCP = struct
                 then `End_of_flow
                 else `Input (filled + len))) in
         Lwt.catch (fun () ->
-            if not (Lwt_unix.readable t.socket)
+            if (not (Lwt_unix.readable t.socket)) && not t.recv_first
             then Lwt.return_ok (`Input 0)
             else process 0 raw)
         @@ function
@@ -385,8 +412,14 @@ module TCP = struct
       let process () =
         Lwt_unix.accept service >>= fun (socket, sockaddr) ->
         let linger = Bytes.create 0x1000 in
-        Lwt.return_ok { Protocol.socket; sockaddr; linger; closed = false }
-      in
+        Lwt.return_ok
+          {
+            Protocol.socket;
+            sockaddr;
+            linger;
+            closed = false;
+            recv_first = Lwt_unix.readable socket;
+          } in
       Lwt.catch process @@ function
       | Unix.(Unix_error ((EAGAIN | EWOULDBLOCK), _, _)) -> accept service
       | Unix.(Unix_error (EINTR, _, _)) -> accept service

--- a/src/lwt/conduit_lwt.ml
+++ b/src/lwt/conduit_lwt.ml
@@ -15,11 +15,12 @@ let failwith fmt = Format.kasprintf (fun err -> Lwt.fail (Failure err)) fmt
 
 let io_of_flow flow =
   let open Lwt.Infix in
+  let mutex = Lwt_mutex.create () in
   let ic_closed = ref false and oc_closed = ref false in
   let close () =
     if !ic_closed && !oc_closed
     then
-      close flow >>= function
+      Lwt_mutex.with_lock mutex (fun () -> close flow) >>= function
       | Ok () -> Lwt.return_unit
       | Error err -> failwith "%a" pp_error err
     else Lwt.return_unit in
@@ -29,16 +30,17 @@ let io_of_flow flow =
   let oc_close () =
     oc_closed := true ;
     close () in
-  let recv buf off len =
+  let rec rrecv buf off len =
     let raw = Cstruct.of_bigarray buf ~off ~len in
-    recv flow raw >>= function
+    Lwt_mutex.with_lock mutex (fun () -> recv flow raw) >>= function
+    | Ok (`Input 0) -> Lwt_unix.yield () >>= fun () -> rrecv buf off len
     | Ok (`Input len) -> Lwt.return len
     | Ok `End_of_flow -> Lwt.return 0
     | Error err -> failwith "%a" pp_error err in
-  let ic = Lwt_io.make ~close:ic_close ~mode:Lwt_io.input recv in
+  let ic = Lwt_io.make ~close:ic_close ~mode:Lwt_io.input rrecv in
   let send buf off len =
     let raw = Cstruct.of_bigarray buf ~off ~len in
-    send flow raw >>= function
+    Lwt_mutex.with_lock mutex (fun () -> send flow raw) >>= function
     | Ok len -> Lwt.return len
     | Error err -> failwith "%a" pp_error err in
   let oc = Lwt_io.make ~close:oc_close ~mode:Lwt_io.output send in

--- a/tests/ping-pong/with_async.ml
+++ b/tests/ping-pong/with_async.ml
@@ -11,6 +11,8 @@ include Common.Make
             let bind x f = Async.Deferred.bind x ~f
 
             let return = Async.Deferred.return
+
+            let yield () = Async.Deferred.return ()
           end)
           (Async.Condition)
           (struct

--- a/tests/ping-pong/with_lwt.ml
+++ b/tests/ping-pong/with_lwt.ml
@@ -6,7 +6,33 @@ let () = Printexc.record_backtrace true
 
 let () = Ssl.init ()
 
+let reporter ppf =
+  let report src level ~over k msgf =
+    let k _ =
+      over () ;
+      k () in
+    let with_metadata header _tags k ppf fmt =
+      Format.kfprintf k ppf
+        ("%a[%a]: " ^^ fmt ^^ "\n%!")
+        Logs_fmt.pp_header (level, header)
+        Fmt.(styled `Magenta string)
+        (Logs.Src.name src) in
+    msgf @@ fun ?header ?tags fmt -> with_metadata header tags k ppf fmt in
+  { Logs.report }
+
+let () = Fmt_tty.setup_std_outputs ~style_renderer:`Ansi_tty ~utf_8:true ()
+
+let () = Logs.set_reporter (reporter Fmt.stderr)
+
+let () = Logs.set_level ~all:true (Some Logs.Debug)
+
 let failwith fmt = Fmt.kstrf (fun err -> Lwt.fail (Failure err)) fmt
+
+module Lwt = struct
+  include Lwt
+
+  let yield = Lwt_unix.yield
+end
 
 include Common.Make (Lwt) (Lwt_condition)
           (struct


### PR DESCRIPTION
According to the documentation of `conduit-tls`, the implementation with `ocaml-tls` is not thread-safe, something like `both (send flow) (recv flow)` is unsafe. It's mostly about the wrapping of a `Conduit.flow` with `Lwt_io` - because the `flow` can be a TLS flow, we must protect `recv` and `send` with a mutex anyway.

The question behind such patch is: should we protect `conduit-tls` with a mutex - and by this way, we are not mandatory to protect any `flow` with a mutex or should we keep this design? To this existential question, we should make an issue a talk about this issue later - note that this is not a part of the core of `conduit`.

The second patch is about the _first-read_ behavior of `Lwt_io`. I'm not sure how we can properly schedule that but it seems that the `Lwt_io` wants to read first when we start a TLS connection - I suspect that it schedule the action from the underlying state of the socket and, because we receive a part of the handshake, it considers `Conduit.recv` as the first operation. However, for the HTTP/1.1 point-of-view, this is not true when the server expect to receive something - so client and server expect to receive something at the end.

`conduit-tls` is able to produce an opportunity to schedule `Conduit.send` even if we called `Conduit.recv`, it returns `Input 0` (which means that we received nothing, __but__ the connection still is established). On the other side, `recv` given to `Lwt_io` can _yield_ to give the opportunity to the application to scheduler `Conduit.send`/`Lwt_io.write`.

Finally:
1) the question about `conduit-tls` is a bit hard but an issue will be done which describe precisely the situation
2) the problem with `lwt_io` is an inheritance of 1) and it seems that `tls.lwt` fix it in its own way