### PR TITLE
Clean fix lwt io flow

### DIFF
--- a/src/lwt-ssl/conduit_lwt_ssl.ml
+++ b/src/lwt-ssl/conduit_lwt_ssl.ml
@@ -143,4 +143,6 @@ module TCP = struct
 
   let service =
     service_with_ssl service ~file_descr:Protocol.file_descr protocol
+
+  include (val Conduit_lwt.repr protocol)
 end

--- a/src/lwt-ssl/conduit_lwt_ssl.mli
+++ b/src/lwt-ssl/conduit_lwt_ssl.mli
@@ -97,4 +97,11 @@ module TCP : sig
     context:Ssl.context ->
     ?verify:verify ->
     (Lwt_unix.sockaddr, Protocol.flow) endpoint resolver
+
+  type t =
+    ( (Lwt_unix.sockaddr, Conduit_lwt.TCP.Protocol.flow) endpoint,
+      Lwt_ssl.socket )
+    Conduit.value
+
+  type Conduit_lwt.flow += T of t
 end

--- a/src/lwt/conduit_lwt.mli
+++ b/src/lwt/conduit_lwt.mli
@@ -8,6 +8,16 @@ include
 
 val io_of_flow :
   flow -> Lwt_io.input Lwt_io.channel * Lwt_io.output Lwt_io.channel
+(** [io_of_flow flow] creates an input flow and an output flow according
+   to [Lwt_io]. This function, even if it creates something more usable
+   is {b deprecated}. Indeed, [Lwt_io] has its own way to schedule [read]
+   and [write] - you should be aware about that more specially when you
+   use [Conduit_tls] or [Conduit_lwt_ssl].
+
+    Due to a specific behavior, [Lwt_io] does not fit with some specific
+   protocols - non thread-safe protocols, {i send-first} protocols, etc.
+   From these reasons, and even if {!TCP} try to the best to fit under
+   an [Lwt_io], you should not use this function. *)
 
 type ('a, 'b, 'c) service = ('a, 'b, 'c) Service.service
 (** The type for lwt services. *)

--- a/tests/ping-pong/with_lwt.ml
+++ b/tests/ping-pong/with_lwt.ml
@@ -6,26 +6,6 @@ let () = Printexc.record_backtrace true
 
 let () = Ssl.init ()
 
-let reporter ppf =
-  let report src level ~over k msgf =
-    let k _ =
-      over () ;
-      k () in
-    let with_metadata header _tags k ppf fmt =
-      Format.kfprintf k ppf
-        ("%a[%a]: " ^^ fmt ^^ "\n%!")
-        Logs_fmt.pp_header (level, header)
-        Fmt.(styled `Magenta string)
-        (Logs.Src.name src) in
-    msgf @@ fun ?header ?tags fmt -> with_metadata header tags k ppf fmt in
-  { Logs.report }
-
-let () = Fmt_tty.setup_std_outputs ~style_renderer:`Ansi_tty ~utf_8:true ()
-
-let () = Logs.set_reporter (reporter Fmt.stderr)
-
-let () = Logs.set_level ~all:true (Some Logs.Debug)
-
 let failwith fmt = Fmt.kstrf (fun err -> Lwt.fail (Failure err)) fmt
 
 module Lwt = struct


### PR DESCRIPTION
So, I don't really know why we decided to use `Lwt_io` but it seems a bad choice which was may be lead by the ability to create such value with `Lwt_ssl.out_channel_of_descr`/`Lwt_ssl.in_channel_of_descr` on the other side. This is not the first issue about `Lwt_io` (double-close for example) but `cohttp` trust on that and we must tweak implementation of protocols to be able to re-schedule fibers when the socket is not _readable_.

I hope that this is the last fix to fit into `Lwt_io` but we definitely should think to remove the usage of it - specially when a protocol such as HTTP/1.1 requires a full control of when we want to read and when we want to write (eg. `http/af`).

This PR is mostly a clean-up about the mix between `Lwt_io`/`Conduit_lwt.TCP`/`Conduit_lwt_tls.TCP` which keeps tests right and should fix issues on `cohttp` then. This error is more, from my point-of-view, about a technical debt which is outside the scope of `mirage` when we chosen to use `Lwt_io`.

I added a comment which tells to the user to __not__ use `Conduit_lwt.io_of_flow` too.