### PR TITLE
howto: no need to manually initialize the rng (conduit_lwt_tls does this for us)

### DIFF
--- a/src/core/howto.mld
+++ b/src/core/howto.mld
@@ -176,8 +176,6 @@ we will use them to upgrade our protocol (when the scheme is ["pgs"]):
 
 {v server.ml v}
 {[
-let () = Mirage_crypto_rng_unix.initialize ()
-
 let load_file filename =
   let ic = open_in filename in
   let ln = in_channel_length ic in
@@ -226,8 +224,6 @@ And for the client, we just need to update the function [conduit_of_uri]:
 {v client.ml v}
 {[
 let tls_config = Tls.Config.client ~authenticator:(fun ~host:_ _ -> Ok None) ()
-
-let () = Mirage_crypto_rng_unix.initialize ()
 
 let conduit_of_uri uri =
   let host = Uri.host_with_default ~default:"localhost" uri in

--- a/tests/ping-pong/with_lwt.ml
+++ b/tests/ping-pong/with_lwt.ml
@@ -1,7 +1,5 @@
 open Rresult
 
-let () = Mirage_crypto_rng_unix.initialize ()
-
 let () = Printexc.record_backtrace true
 
 let () = Ssl.init ()


### PR DESCRIPTION
the initialization via Mirage_crypto_rng_unix.initialize is meant for non-lwt programs, since there is only an initial seeding of the RNG, and no periodic reseeding.

Since this example / howto is well-advertised, let's remove the manual initialization -- the conduit-lwt-tls package already takes care of it (using Mirage_crypto_rng_lwt.initialize -- which periodically collects entropy from getrandom/getentropy and rdrand/rdseed).