### PR TITLE
Conduit_{lwt,async}.serve does not need the protocol anymore

### DIFF
--- a/src/async-ssl/conduit_async_ssl.ml
+++ b/src/async-ssl/conduit_async_ssl.ml
@@ -284,7 +284,7 @@ let service_with_ssl :
     writer:(flow -> Writer.t) ->
     (edn, flow with_ssl) Conduit_async.protocol ->
     (context * cfg, context * t, flow with_ssl) Conduit_async.Service.service =
- fun service ~reader ~writer _ ->
+ fun service ~reader ~writer protocol ->
   let module S = (val Conduit_async.Service.impl service) in
   let module Service = struct
     include S
@@ -294,7 +294,7 @@ let service_with_ssl :
     let writer = writer
   end in
   let module M = Make (Service) in
-  Conduit_async.Service.register ~service:(module M)
+  Conduit_async.Service.register ~service:(module M) ~protocol
 
 module TCP = struct
   open Conduit_async.TCP

--- a/src/async/conduit_async.mli
+++ b/src/async/conduit_async.mli
@@ -15,8 +15,8 @@ type ('a, 'b, 'c) service = ('a, 'b, 'c) Service.service
 
 val serve :
   ?timeout:int ->
-  handler:('flow -> unit Async.Deferred.t) ->
-  service:('cfg, 'master, 'flow) service ->
+  handler:(flow -> unit Async.Deferred.t) ->
+  service:('cfg, 't, 'v) service ->
   'cfg ->
   unit Async.Condition.t * (unit -> unit Async.Deferred.t)
 (** [serve ~handler ~service cfg] creates an usual infinite [service]

--- a/src/core/dune
+++ b/src/core/dune
@@ -1,7 +1,7 @@
 (library
  (name conduit)
  (public_name conduit)
- (libraries stdlib-shims ipaddr domain-name))
+ (libraries stdlib-shims logs ipaddr domain-name))
 
 (documentation
  (package conduit)

--- a/src/lwt-ssl/conduit_lwt_ssl.ml
+++ b/src/lwt-ssl/conduit_lwt_ssl.ml
@@ -116,14 +116,14 @@ let service_with_ssl :
     file_descr:(flow -> Lwt_unix.file_descr) ->
     (edn, Lwt_ssl.socket) Conduit_lwt.protocol ->
     (Ssl.context * cfg, t service, Lwt_ssl.socket) Conduit_lwt.Service.service =
- fun service ~file_descr _ ->
+ fun service ~file_descr protocol ->
   let module S = (val Conduit_lwt.Service.impl service) in
   let module M = Service (struct
     include S
 
     let file_descr = file_descr
   end) in
-  Conduit_lwt.Service.register ~service:(module M)
+  Conduit_lwt.Service.register ~service:(module M) ~protocol
 
 module TCP = struct
   let resolve ~port ~context ?verify domain_name =

--- a/src/lwt/conduit_lwt.mli
+++ b/src/lwt/conduit_lwt.mli
@@ -24,8 +24,8 @@ type ('a, 'b, 'c) service = ('a, 'b, 'c) Service.service
 
 val serve :
   ?timeout:int ->
-  handler:('flow -> unit Lwt.t) ->
-  service:('cfg, 'service, 'flow) service ->
+  handler:(flow -> unit Lwt.t) ->
+  service:('cfg, 'service, 'v) service ->
   'cfg ->
   unit Lwt_condition.t * (unit -> unit Lwt.t)
 (** [serve ~handler ~service cfg] creates an usual infinite [service]

--- a/src/tls/conduit_tls.ml
+++ b/src/tls/conduit_tls.ml
@@ -364,8 +364,8 @@ struct
         t service_with_tls,
         flow protocol_with_tls )
       Conduit.Service.service =
-   fun service _ ->
+   fun service protocol ->
     let module Service = (val Conduit.Service.impl service) in
     let module M = Make_server (Service) in
-    Conduit.Service.register ~service:(module M)
+    Conduit.Service.register ~service:(module M) ~protocol
 end

--- a/tests/ping-pong/common.ml
+++ b/tests/ping-pong/common.ml
@@ -5,8 +5,8 @@ module type S = sig
 
   val serve :
     ?timeout:int ->
-    handler:('flow -> unit io) ->
-    service:('cfg, 'master, 'flow) Service.service ->
+    handler:(flow -> unit io) ->
+    service:('cfg, 'master, 'v) Service.service ->
     'cfg ->
     unit condition * (unit -> unit io)
 end
@@ -112,15 +112,11 @@ struct
     | Ok () -> return ()
 
   let server :
-      type cfg service flow.
+      type cfg service.
       cfg ->
-      protocol:(_, flow) Conduit.protocol ->
-      service:(cfg, service, flow) Conduit.Service.service ->
+      service:(cfg, service, 'flow) Conduit.Service.service ->
       unit Condition.t * (unit -> unit IO.t) =
-   fun cfg ~protocol ~service ->
-    Conduit.serve
-      ~handler:(fun flow -> transmission (Conduit.pack protocol flow))
-      ~service cfg
+   fun cfg ~service -> Conduit.serve ~handler:transmission ~service cfg
 
   (* part *)
 

--- a/tests/ping-pong/with_async.ml
+++ b/tests/ping-pong/with_async.ml
@@ -47,12 +47,11 @@ let localhost = Domain_name.(host_exn (of_string_exn "localhost"))
 let run_with :
     type cfg service flow.
     cfg ->
-    protocol:(_, flow) Conduit_async.protocol ->
     service:(cfg, service, flow) Conduit_async.Service.service ->
     string list ->
     unit =
- fun cfg ~protocol ~service clients ->
-  let stop, server = server (* ~launched ~stop *) cfg ~protocol ~service in
+ fun cfg ~service clients ->
+  let stop, server = server (* ~launched ~stop *) cfg ~service in
   let clients =
     Async.after Core.Time.Span.(of_sec 0.5) >>= fun () ->
     (* XXX(dinosaure): [async] tries to go further and fibers
@@ -70,7 +69,7 @@ let run_with :
 let run_with_tcp clients =
   run_with
     (Conduit_async.TCP.Listen (None, Tcp.Where_to_listen.of_port 5000))
-    ~protocol:tcp_protocol ~service:tcp_service clients
+    ~service:tcp_service clients
 
 let load_file filename =
   let open Stdlib in
@@ -95,7 +94,7 @@ let run_with_tls cert key clients =
   let ctx = config cert key in
   run_with
     (Conduit_async.TCP.Listen (None, Tcp.Where_to_listen.of_port 9000), ctx)
-    ~protocol:tls_protocol ~service:tls_service clients
+    ~service:tls_service clients
 
 let () =
   match Array.to_list Stdlib.Sys.argv with

--- a/tests/ping-pong/with_lwt.ml
+++ b/tests/ping-pong/with_lwt.ml
@@ -60,12 +60,11 @@ let config cert key =
 let run_with :
     type cfg service flow.
     cfg ->
-    protocol:(_, flow) Conduit_lwt.protocol ->
     service:(cfg, service, flow) Conduit_lwt.Service.service ->
     string list ->
     unit =
- fun cfg ~protocol ~service clients ->
-  let stop, server = server cfg ~protocol ~service in
+ fun cfg ~service clients ->
+  let stop, server = server cfg ~service in
   let clients = List.map (client ~resolvers) clients in
   let clients =
     Lwt.join clients >>= fun () ->
@@ -79,7 +78,7 @@ let run_with_tcp clients =
       Conduit_lwt.TCP.sockaddr = Unix.ADDR_INET (Unix.inet_addr_loopback, 4000);
       capacity = 40;
     }
-    ~protocol:Conduit_lwt.TCP.protocol ~service:Conduit_lwt.TCP.service clients
+    ~service:Conduit_lwt.TCP.service clients
 
 let run_with_tls cert key clients =
   let ctx = config cert key in
@@ -89,7 +88,7 @@ let run_with_tls cert key clients =
         capacity = 40;
       },
       ctx )
-    ~protocol:tls_protocol ~service:tls_service clients
+    ~service:tls_service clients
 
 let () =
   match Array.to_list Sys.argv with


### PR DESCRIPTION
After a discussion about `cohttp`, it seems that the rational behind this signature:
```ocaml
val serve : 'cfg
  -> protocol:(_, 'flow) Conduit.protocol
  -> service:('cfg, 'service, 'flow) Conduit.Service.service
  -> handler:('flow -> unit io)
  -> unit io
```

is not so clear and can lead the user to some compilation errors (when `protocol` and `service` don't have the same `'flow` type) or runtime errors[1]. This PR is a revert of [this specific commit](https://github.com/mirage/ocaml-conduit/pull/311/commits/c84a6b45ecbe0b6846dd48d9619ab2c0df3220a2) which comes from a nightly agreement with @samoht.  But it seems that the final result is not good according to this comment: https://github.com/mirage/ocaml-cohttp/pull/732#discussion_r518744814

This PR provides an new interface (so, it breaks the current API):
```ocaml
val serve : 'cfg
  -> service:('cfg, 'service, _) Conduit.Service.service
  -> handler:(Conduit.flow -> unit io)
  -> unit io
```

Note that if the user wants to directly get the concrete value `'flow`, he is able to do that with `Conduit.Service.impl service` and the real implementation of the service (with concrete types). With the new interface of `serve`, as a Conduit's protocol, the user is still able to _destruct_ the value to its concrete type.

For the `cohttp`'s point-of-view, it will __just__ delete the `protocol` argument when we want to launch a CoHTTP server.

About release, Conduit 3.0.0 is currently not used by any released packages, so:
- we can lie and redo the release of Conduit 3.0.0
- we can do a Conduit 3.1.0 and explain the rational under this API update

cc @mirage/core @avsm @samoht 

[1]: a runtime error can exists when the user wants to serve with a service and a protocol and both don't come from the same place (and don't share the same logic, axiom, etc on their implementations but they share the same type).