### PR TITLE
Simplify Conduit.repr

### DIFF
--- a/src/core/conduit.mli
+++ b/src/core/conduit.mli
@@ -6,9 +6,6 @@ type resolvers
 val empty : resolvers
 (** [empty] is an empty {!resolvers} map. *)
 
-type ('edn, 'flow) value = ('edn, 'flow) Conduit_intf.value =
-  | Value : 'flow -> ('edn, 'flow) value
-
 module type S = Conduit_intf.S
 (** @inline *)
 

--- a/src/core/e0.ml
+++ b/src/core/e0.ml
@@ -100,7 +100,7 @@ module Make (Key : S1) = struct
 
   type v = Value : 'a * 'a Key.t -> v
 
-  type k = Key : 'a Key.t * ('a -> t) -> k
+  type k = Key : 'a Key.t -> k
 
   let equal : type a b. a s -> b s -> (a, b) refl option =
    fun a b ->
@@ -127,7 +127,7 @@ module Make (Key : S1) = struct
 
     let witness = X.witness
 
-    let key = Key (witness, fun x -> T x)
+    let key = Key witness
 
     let value x = Value (x, witness)
 

--- a/src/core/e0.mli
+++ b/src/core/e0.mli
@@ -24,7 +24,7 @@ module Make (Key : S1) : sig
 
   type v = Value : 'a * 'a Key.t -> v
 
-  type k = Key : 'a Key.t * ('a -> t) -> k
+  type k = Key : 'a Key.t -> k
 
   val equal : 'a s -> 'b s -> ('a, 'b) refl option
 

--- a/src/core/readme.mld
+++ b/src/core/readme.mld
@@ -170,10 +170,8 @@ The end user is then able to {i destruct} the flow to this type:
 
 {[
 let hello (flow : Conduit.flow) = match flow with
-  | T (Value file_descr) ->
-    Unix.write file_descr "Hello World!"
-  | flow ->
-    Conduit.send flow "Hello World!"
+  | T file_descr -> Unix.write file_descr "Hello World!"
+  | flow -> Conduit.send flow "Hello World!"
 ]}
 
 Of course, we can not assert that the given [flow] is, in any case, an

--- a/src/lwt-ssl/conduit_lwt_ssl.mli
+++ b/src/lwt-ssl/conduit_lwt_ssl.mli
@@ -97,10 +97,5 @@ module TCP : sig
     ?verify:verify ->
     (Lwt_unix.sockaddr, Protocol.flow) endpoint resolver
 
-  type t =
-    ( (Lwt_unix.sockaddr, Conduit_lwt.TCP.Protocol.flow) endpoint,
-      Lwt_ssl.socket )
-    Conduit.value
-
-  type Conduit_lwt.flow += T of t
+  type Conduit_lwt.flow += T of Lwt_ssl.socket
 end

--- a/src/lwt-tls/conduit_lwt_tls.mli
+++ b/src/lwt-tls/conduit_lwt_tls.mli
@@ -40,12 +40,7 @@ module TCP : sig
       Protocol.flow protocol_with_tls )
     protocol
 
-  type t =
-    ( Lwt_unix.sockaddr * Tls.Config.client,
-      Protocol.flow protocol_with_tls )
-    Conduit.value
-
-  type Conduit_lwt.flow += T of t
+  type Conduit_lwt.flow += T of Protocol.flow protocol_with_tls
 
   val service :
     ( configuration * Tls.Config.server,

--- a/src/lwt/conduit_lwt.mli
+++ b/src/lwt/conduit_lwt.mli
@@ -112,9 +112,7 @@ module TCP : sig
 
   val protocol : (Lwt_unix.sockaddr, Protocol.flow) protocol
 
-  type t = (Lwt_unix.sockaddr, Protocol.flow) Conduit.value
-
-  type flow += T of t
+  type flow += T of Protocol.flow
 
   val service : (configuration, Service.t, Protocol.flow) service
 

--- a/tests/flow.ml
+++ b/tests/flow.ml
@@ -247,6 +247,64 @@ let test_output_strings =
     (String.concat "" (List.map Bytes.to_string bufs))
     "Hello World!"
 
+(* XXX(dinosaure): ensure type equality. *)
+
+module Dummy_flow = struct
+  type input = bytes
+
+  type output = string
+
+  type +'a io = 'a
+
+  type flow = Flow
+
+  type error = |
+
+  let pp_error : Format.formatter -> error -> unit = fun _ -> function _ -> .
+
+  let recv Flow _ = Ok `End_of_flow
+
+  let send Flow _ = Ok 0
+
+  let close Flow = Ok ()
+end
+
+module Dummy_protocol = struct
+  include Dummy_flow
+
+  type endpoint = |
+
+  let connect : endpoint -> (flow, error) result io = function _ -> .
+end
+
+module Dummy_service = struct
+  include Dummy_flow
+
+  type configuration = Configuration
+
+  type t = T
+
+  let init Configuration = Ok T
+
+  let accept T = Ok Flow
+
+  let close T = Ok ()
+end
+
+let dummy_protocol = Conduit.register (module Dummy_protocol)
+
+let dummy_service =
+  Conduit.Service.register (module Dummy_service) dummy_protocol
+
+let test_type_equality =
+  Alcotest.test_case "type equality" `Quick @@ fun () ->
+  let[@warning "-8"] (Ok t) =
+    Conduit.Service.init dummy_service Dummy_service.Configuration in
+  let module Repr = (val Conduit.repr dummy_protocol) in
+  match Conduit.Service.accept dummy_service t with
+  | Ok (Repr.T Dummy_flow.Flow) -> Alcotest.(check pass) "type equality" () ()
+  | _ -> Alcotest.failf "Invalid flow value"
+
 let tests =
   [
     ( "flow",
@@ -255,5 +313,6 @@ let tests =
         test_output_string;
         test_input_strings;
         test_output_strings;
+        test_type_equality;
       ] );
   ]


### PR DESCRIPTION
Remove the intermediate value type which was not necessary

Extracted from #338 