### PR TITLE
Conduit.connect: swap argument order to use a "t-first" convention

### DIFF
--- a/bench/cost.ml
+++ b/bench/cost.ml
@@ -145,7 +145,7 @@ let print_stdout est0 est1 r0 r1 =
 
 let run json =
   let open Rresult in
-  Tuyau.connect Unix.stderr fake0 >>= fun flow ->
+  Tuyau.connect fake0 Unix.stderr >>= fun flow ->
   Tuyau.send flow hello_world >>= fun _ ->
   let samples0 = Benchmark.run (fn_fully_abstr flow) in
   let samples1 = Benchmark.run (fn_abstr flow) in

--- a/src/core/conduit.ml
+++ b/src/core/conduit.ml
@@ -346,8 +346,8 @@ module Make (IO : IO) (Input : BUFFER) (Output : BUFFER) :
         go l
 
   let connect :
-      type edn v. edn -> (edn, v) protocol -> (flow, [> error ]) result io =
-   fun edn { protocol = (module Witness); _ } ->
+      type edn v. (edn, v) protocol -> edn -> (flow, [> error ]) result io =
+   fun { protocol = (module Witness); _ } edn ->
     let (Protocol (_, (module Flow), (module Protocol))) = Witness.witness in
     Protocol.connect edn >>| reword_error (msgf "%a" Protocol.pp_error)
     >>? fun flow -> return (Ok (Flow.T flow))

--- a/src/core/conduit_intf.ml
+++ b/src/core/conduit_intf.ml
@@ -398,7 +398,7 @@ module type S = sig
           | flow -> ignore @@ send flow "Hello World!"
       ]} *)
 
-  val connect : 'edn -> ('edn, _) protocol -> (flow, [> error ]) result io
+  val connect : ('edn, _) protocol -> 'edn -> (flow, [> error ]) result io
 
   (** {2:service Server-side conduits.} *)
 

--- a/tests/flow.ml
+++ b/tests/flow.ml
@@ -86,7 +86,7 @@ let memory0 = Conduit.register (module Memory_flow0)
 let test_input_string =
   Alcotest.test_case "input string" `Quick @@ fun () ->
   let open Rresult in
-  let flow = Conduit.connect ("Hello World!", Bytes.empty) memory0 in
+  let flow = Conduit.connect memory0 ("Hello World!", Bytes.empty) in
   Alcotest.(check bool) "connect" (R.is_ok flow) true ;
   let flow = R.get_ok flow in
   let buf0 = Bytes.create 12 in
@@ -105,7 +105,7 @@ let test_output_string =
   Alcotest.test_case "output string" `Quick @@ fun () ->
   let open Rresult in
   let buf = Bytes.create 12 in
-  let flow = Conduit.connect ("", buf) memory0 in
+  let flow = Conduit.connect memory0 ("", buf) in
   Alcotest.(check bool) "connect" (R.is_ok flow) true ;
   let flow = R.get_ok flow in
   let res0 = Conduit.send flow "Hell" in
@@ -204,7 +204,7 @@ let test_input_strings =
   Alcotest.test_case "input strings" `Quick @@ fun () ->
   let open Rresult in
   let flow =
-    Conduit.connect ([ ""; "123"; "45"; "6789"; "0" ], [ Bytes.empty ]) memory1
+    Conduit.connect memory1 ([ ""; "123"; "45"; "6789"; "0" ], [ Bytes.empty ])
   in
   Alcotest.(check bool) "connect" (R.is_ok flow) true ;
   let flow = R.get_ok flow in
@@ -229,7 +229,7 @@ let test_output_strings =
   Alcotest.test_case "output strings" `Quick @@ fun () ->
   let open Rresult in
   let bufs = [ Bytes.create 4; Bytes.empty; Bytes.create 2; Bytes.create 6 ] in
-  let flow = Conduit.connect ([], bufs) memory1 in
+  let flow = Conduit.connect memory1 ([], bufs) in
   Alcotest.(check bool) "connect" (R.is_ok flow) true ;
   let flow = R.get_ok flow in
   let res0 = Conduit.send flow "Hello" in


### PR DESCRIPTION
Extracted from #338 