### PR TITLE
core: expand aliases exposed in _intf file

### DIFF
--- a/src/core/conduit.mli
+++ b/src/core/conduit.mli
@@ -1,22 +1,2 @@
-module Endpoint = Endpoint
-
-type resolvers
-(** Type for resolvers map. *)
-
-val empty : resolvers
-(** [empty] is an empty {!resolvers} map. *)
-
-module type S = Conduit_intf.S
+include Conduit_intf.Conduit
 (** @inline *)
-
-module type IO = Conduit_intf.IO
-(** @inline *)
-
-module type BUFFER = Conduit_intf.BUFFER
-(** @inline *)
-
-module Make (IO : IO) (Input : BUFFER) (Output : BUFFER) :
-  S
-    with type input = Input.t
-     and type output = Output.t
-     and type +'a io = 'a IO.t

--- a/src/core/conduit_intf.ml
+++ b/src/core/conduit_intf.ml
@@ -494,3 +494,34 @@ module type S = sig
     (** [impl service] is [service]'s underlying implementation. *)
   end
 end
+
+module type Conduit = sig
+  module Endpoint = Endpoint
+
+  type resolvers
+  (** Type for resolvers map. *)
+
+  val empty : resolvers
+  (** [empty] is an empty {!resolvers} map. *)
+
+  module type S = sig
+    include S
+    (** @inline *)
+  end
+
+  module type IO = sig
+    include IO
+    (** @inline *)
+  end
+
+  module type BUFFER = sig
+    include BUFFER
+    (** @inline *)
+  end
+
+  module Make (IO : IO) (Input : BUFFER) (Output : BUFFER) :
+    S
+      with type input = Input.t
+       and type output = Output.t
+       and type +'a io = 'a IO.t
+end

--- a/src/core/conduit_intf.ml
+++ b/src/core/conduit_intf.ml
@@ -524,4 +524,21 @@ module type Conduit = sig
       with type input = Input.t
        and type output = Output.t
        and type +'a io = 'a IO.t
+
+  (** General module types re-exported for convenience. *)
+
+  module type FLOW = sig
+    include FLOW
+    (** @inline *)
+  end
+
+  module type PROTOCOL = sig
+    include PROTOCOL
+    (** @inline *)
+  end
+
+  module type SERVICE = sig
+    include SERVICE
+    (** @inline *)
+  end
 end

--- a/src/core/conduit_intf.ml
+++ b/src/core/conduit_intf.ml
@@ -498,6 +498,8 @@ end
 module type Conduit = sig
   module Endpoint = Endpoint
 
+  type nonrec ('a, 'b) refl = ('a, 'b) refl
+
   type resolvers
   (** Type for resolvers map. *)
 


### PR DESCRIPTION
This ensures that the OCaml toplevel is able to introspect these signatures directly  and prevents references to module types in `Conduit_intf` from escaping to the user.

Fixes https://github.com/mirage/ocaml-conduit/issues/356.