### PR TITLE
Re-export Conduit.Refl constructor

### DIFF
--- a/src/core/conduit.mli
+++ b/src/core/conduit.mli
@@ -1,2 +1,4 @@
+type ('a, 'b) refl = ('a, 'b) Conduit_intf.refl = Refl : ('a, 'a) refl
+
 include Conduit_intf.Conduit
 (** @inline *)

--- a/src/core/conduit_intf.ml
+++ b/src/core/conduit_intf.ml
@@ -498,8 +498,6 @@ end
 module type Conduit = sig
   module Endpoint = Endpoint
 
-  type nonrec ('a, 'b) refl = ('a, 'b) refl
-
   type resolvers
   (** Type for resolvers map. *)
 


### PR DESCRIPTION
Until #357 we need to re-export correctly `Refl` because it is used by CoHTTP and required when we want to _pattern-match_ the result of:
https://github.com/mirage/ocaml-conduit/blob/7375b559cde825e66b0805129f51464174f20eb1/src/core/conduit_intf.ml#L416-L429