### PR TITLE
Better lwt tcp protocol

### DIFF
--- a/tests/ping-pong/common.ml
+++ b/tests/ping-pong/common.ml
@@ -73,7 +73,6 @@ struct
       | None -> (
           Conduit.recv flow tmp >>? function
           | `End_of_flow -> IO.return (Ok `Close)
-          | `Input 0 -> IO.yield () >>= go
           | `Input len ->
               Ke.Rke.N.push queue ~blit ~length:Cstruct.len ~off:0 ~len tmp ;
               go ()) in


### PR DESCRIPTION
This code will break the `ping-pong` test but it is a part of several incoming PR about the TLS stack. This update is requested from @talex5 about a clear behavior of `recv` and `send`. The documentation was updated according to the new behavior and we ensure to call only one and unique time underlying `Lwt_unix.{read,write}` _syscalls_. 

This PR is less error-prone and less complex than before. It delete a weird case `Input 0` (which was needed to call `yield ()`).