### PR TITLE
Tls thread safe

### DIFF
--- a/src/async-tls/conduit_async_tls.ml
+++ b/src/async-tls/conduit_async_tls.ml
@@ -1,12 +1,28 @@
 open Async
-include Conduit_tls.Make (Conduit_async.IO) (Conduit_async)
+
+module IO = struct
+  type +'a t = 'a Async.Deferred.t
+
+  let bind x f = Async.Deferred.bind x ~f
+
+  let return = Async.Deferred.return
+
+  let catch f ferr =
+    Async.try_with ~extract_exn:true f >>= function
+    | Ok v -> return v
+    | Error exn -> ferr exn
+
+  let fail exn = raise exn
+end
+
+include Conduit_tls.Make (IO) (Conduit_async)
 
 module TCP = struct
   open Conduit_async.TCP
 
   let protocol = protocol_with_tls protocol
 
-  let service = service_with_tls service protocol
+  let service = service_with_tls service Conduit_async.TCP.protocol protocol
 
   let configuration ~config:tls_config ?backlog listen =
     (configuration ?backlog listen, tls_config)

--- a/src/async-tls/conduit_async_tls.mli
+++ b/src/async-tls/conduit_async_tls.mli
@@ -9,6 +9,7 @@ val underlying : 'flow protocol_with_tls -> 'flow
 val handshake : 'flow protocol_with_tls -> bool
 
 val protocol_with_tls :
+  ?host_of_endpoint:('edn -> string option) ->
   ('edn, 'flow) protocol ->
   ('edn * Tls.Config.client, 'flow protocol_with_tls) protocol
 
@@ -16,7 +17,8 @@ type 'service service_with_tls
 
 val service_with_tls :
   ('cfg, 't, 'flow) Service.t ->
-  ('edn, 'flow protocol_with_tls) protocol ->
+  ('edn, 'flow) protocol ->
+  ('edn * Tls.Config.client, 'flow protocol_with_tls) protocol ->
   ( 'cfg * Tls.Config.server,
     't service_with_tls,
     'flow protocol_with_tls )

--- a/src/lwt-tls/conduit_lwt_tls.ml
+++ b/src/lwt-tls/conduit_lwt_tls.ml
@@ -1,4 +1,16 @@
-include Conduit_tls.Make (Conduit_lwt.IO) (Conduit_lwt)
+module IO = struct
+  type +'a t = 'a Lwt.t
+
+  let bind = Lwt.bind
+
+  let return = Lwt.return
+
+  let fail = Lwt.fail
+
+  let catch = Lwt.catch
+end
+
+include Conduit_tls.Make (IO) (Conduit_lwt)
 
 let () = Mirage_crypto_rng_lwt.initialize ()
 
@@ -9,7 +21,7 @@ module TCP = struct
 
   include (val Conduit_lwt.repr protocol)
 
-  let service = service_with_tls service protocol
+  let service = service_with_tls service Conduit_lwt.TCP.protocol protocol
 
   let resolve ~port ~config domain_name =
     let open Lwt.Infix in

--- a/src/lwt-tls/conduit_lwt_tls.mli
+++ b/src/lwt-tls/conduit_lwt_tls.mli
@@ -19,6 +19,7 @@ val handshake : 'flow protocol_with_tls -> bool
     it returns [false]. *)
 
 val protocol_with_tls :
+  ?host_of_endpoint:('edn -> string option) ->
   ('edn, 'flow) protocol ->
   ('edn * Tls.Config.client, 'flow protocol_with_tls) protocol
 
@@ -26,7 +27,8 @@ type 'service service_with_tls
 
 val service_with_tls :
   ('cfg, 't, 'flow) Service.t ->
-  ('edn, 'flow protocol_with_tls) protocol ->
+  ('edn, 'flow) protocol ->
+  ('edn * Tls.Config.client, 'flow protocol_with_tls) protocol ->
   ( 'cfg * Tls.Config.server,
     't service_with_tls,
     'flow protocol_with_tls )

--- a/src/tls/conduit_tls.mli
+++ b/src/tls/conduit_tls.mli
@@ -1,49 +1,17 @@
-(** Common TLS implementation with Conduit.
+module type IO = sig
+  type +'a t
 
-    The current implementation of the TLS layer over an underlying protocol
-    respects some assumptions and it has a specific behaviour which is decribed
-    here:
+  val bind : 'a t -> ('a -> 'b t) -> 'b t
 
-    The {i handshake} is not done when we initialize the flow. Only a call to
-    [recv] or [send] really starts the handshake with your peer. In that
-    context, a concurrent call of these actions should put some trouble into the
-    handshake and they must be protected by an exclusion.
+  val return : 'a -> 'a t
 
-    In other words due to the non-atomicity of [recv] and [send], while the
-    handshake, you should ensure to finish a call of one of them before to call
-    the other. A mutex should be used in this context to protect the mutual
-    exclusion between [recv] and [send]. In others words, such process is safe:
+  val catch : (unit -> 'a t) -> (exn -> 'a t) -> 'a t
 
-    {[
-      let* _ = Conduit.send tls_flow raw in
-      let* _ = Conduit.recv tls_flow raw in
-    ]}
-
-    Where such process is not safe:
-
-    {[
-      async (fun () -> Conduit.send tls_flow raw) ;
-      async (fun () -> Conduit.recv tls_flow raw)
-    ]}
-
-    The non-atomicity of [send] and [recv] is due to the underlying handshake of
-    TLS which can appear everytime. By this fact, [send] or [recv] (depends
-    which is executed first) can start an handshake process which can call
-    several times underlying [Flow.send] and [Flow.recv] processes (no 0-RTT).
-    If you use [async], the scheduler can misleading/misorder handshake started
-    with one to the other call to [send] and [recv].
-
-    A solution such as a {i mutex} to ensure the exclusivity between [send] and
-    [recv] can be used - it does not exists at this layer where such abstraction
-    is not available.
-
-    This design appear when you use [LWT] or [ASYNC] which can do a concurrence
-    between {i promises}. Without such {i scheduler}, the process is sequential
-    and the OCaml {i scheduler} should not re-order sub-processes of
-    [Conduit.send] and [Conduit.recv]. *)
+  val fail : exn -> 'a t
+end
 
 module Make
-    (IO : Conduit.IO)
+    (IO : IO)
     (Conduit : Conduit.S
                  with type input = Cstruct.t
                   and type output = Cstruct.t
@@ -57,6 +25,7 @@ module Make
   (** [handshake flow] returns [true] if {i handshake} is processing. *)
 
   val protocol_with_tls :
+    ?host_of_endpoint:('edn -> string option) ->
     ('edn, 'flow) Conduit.protocol ->
     ('edn * Tls.Config.client, 'flow protocol_with_tls) Conduit.protocol
   (** From a given protocol [witness], it creates a new {i witness} of the
@@ -66,7 +35,8 @@ module Make
 
   val service_with_tls :
     ('cfg, 't, 'flow) Conduit.Service.t ->
-    ('edn, 'flow protocol_with_tls) Conduit.protocol ->
+    ('edn, 'flow) Conduit.protocol ->
+    ('edn * Tls.Config.client, 'flow protocol_with_tls) Conduit.protocol ->
     ( 'cfg * Tls.Config.server,
       't service_with_tls,
       'flow protocol_with_tls )


### PR DESCRIPTION
This update want to assert a thread-safe implementation of the TLS layer. The implementation comes from `tls.lwt` and was copy/paste (minor mirleft/ocaml-tls#422, a functor to unlock the ability of the composition and `ocamlformat`). CI will fails and we need to merge #362.

An other aspect is the needed unencrypted way to communicate to the client from the server to _drain_ the handshake. Composition is bit more complex than before to make a TLS service from _a protocol_: the service requires the protocol with TLS (as explained in #337 and #338 to be able to wrap the flow into the right _constructor_) and it requires the protocol **without** TLS to be able to _drain_ (and use `recv`/`send`) the handshake before to return to the end-user the flow.