### PR TITLE
Remove unused Conduit.S.resolvers type

### DIFF
--- a/src/core/conduit.ml
+++ b/src/core/conduit.ml
@@ -70,6 +70,10 @@ end) : BIJECTION with type +'a s = 'a Functor.t = struct
   external prj : ('a, t) app -> 'a s = "%identity"
 end
 
+module type S = sig
+  include S with type resolvers := resolvers
+end
+
 module Make (IO : IO) (Input : BUFFER) (Output : BUFFER) :
   S
     with type input = Input.t
@@ -221,8 +225,6 @@ module Make (IO : IO) (Input : BUFFER) (Output : BUFFER) :
   let repr t = Flow.repr t.flow
 
   let ( <.> ) f g x = f (g x)
-
-  type nonrec resolvers = resolvers
 
   let empty = empty
 

--- a/src/core/conduit_intf.ml
+++ b/src/core/conduit_intf.ml
@@ -335,6 +335,7 @@ module type S = sig
   type resolvers
 
   val empty : resolvers
+  (** [empty] is equal to {!Conduit.empty}. *)
 
   val add :
     ('edn, _) protocol ->
@@ -505,7 +506,7 @@ module type Conduit = sig
   (** [empty] is an empty {!resolvers} map. *)
 
   module type S = sig
-    include S
+    include S with type resolvers := resolvers
     (** @inline *)
   end
 


### PR DESCRIPTION
The internal implementation ensures `Conduit.resolvers` = `Conduit.Make(...).resolvers`, but this isn't exposed to the user so I think this type is useless.