### PR TITLE
Gitignore opam/ when it is a symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 _build/
-_opam/
+_opam
 sandbox/
 .*.swp
 *.install


### PR DESCRIPTION
The `opam/` pattern doesn't apply to local switches created with `opam link` (which are not directories).