### PR TITLE
[v2] conduit-mirage: simplify the API

### DIFF
--- a/conduit-mirage.opam
+++ b/conduit-mirage.opam
@@ -27,6 +27,7 @@ depends: [
   "ca-certs-nss"
   "ipaddr" {>= "3.0.0"}
   "ipaddr-sexp"
+  "tcpip" {with-test}
 ]
 conflicts: [
   "mirage-conduit"

--- a/src/conduit-mirage/resolver_mirage.ml
+++ b/src/conduit-mirage/resolver_mirage.ml
@@ -17,50 +17,14 @@
 
 open Lwt.Infix
 
-let is_tls_service =
-  (* TODO fill in the blanks. nowhere else to get this information *)
-  function
-  | "https" | "imaps" -> true
-  | _ -> false
+module type S = sig
+  include Resolver_lwt.S
 
-let get_host uri =
-  match Uri.host uri with
-  | None -> "localhost"
-  | Some host -> (
-      match Ipaddr.of_string host with
-      | Ok ip -> Ipaddr.to_string ip
-      | Error _ -> host)
+  val static : (string, port:int -> Conduit.endp) Hashtbl.t -> t
+  val localhost : t
+end
 
-let get_port service uri =
-  match Uri.port uri with None -> service.Resolver.port | Some port -> port
-
-let static_resolver hosts service uri =
-  let port = get_port service uri in
-  try
-    let fn = Hashtbl.find hosts (get_host uri) in
-    Lwt.return (fn ~port)
-  with Not_found -> Lwt.return (`Unknown "name resolution failed")
-
-let static_service name =
-  match Uri_services.tcp_port_of_service name with
-  | [] -> Lwt.return_none
-  | port :: _ ->
-      let tls = is_tls_service name in
-      let svc = { Resolver.name; port; tls } in
-      Lwt.return (Some svc)
-
-let static hosts =
-  let service = static_service in
-  let rewrites = [ ("", static_resolver hosts) ] in
-  Resolver_lwt.init ~service ~rewrites ()
-
-let localhost =
-  let hosts = Hashtbl.create 3 in
-  Hashtbl.add hosts "localhost" (fun ~port ->
-      `TCP (Ipaddr.(V4 V4.localhost), port));
-  static hosts
-
-module Make_with_stack
+module Make
     (R : Mirage_random.S)
     (T : Mirage_time.S)
     (C : Mirage_clock.MCLOCK)
@@ -68,62 +32,102 @@ module Make_with_stack
 struct
   include Resolver_lwt
 
-  module R = struct
-    let vchan_resolver ~tld =
-      let tld_len = String.length tld in
-      let get_short_host uri =
-        let n = get_host uri in
-        let len = String.length n in
-        if len > tld_len && String.sub n (len - tld_len) tld_len = tld then
-          String.sub n 0 (len - tld_len)
-        else n
-      in
-      fun service uri ->
-        (* Strip the tld from the hostname *)
-        let remote_name = get_short_host uri in
-        Printf.printf "vchan_lookup: %s %s -> normalizes to %s\n%!"
-          (Sexplib.Sexp.to_string_hum (Resolver.sexp_of_service service))
-          (Uri.to_string uri) remote_name;
-        Lwt.return (`Vchan_domain_socket (remote_name, service.Resolver.name))
+  let is_tls_service =
+    (* TODO fill in the blanks. nowhere else to get this information *)
+    function
+    | "https" | "imaps" -> true
+    | _ -> false
 
-    module DNS = Dns_client_mirage.Make (R) (T) (C) (S)
+  let get_host uri =
+    match Uri.host uri with
+    | None -> "localhost"
+    | Some host -> (
+        match Ipaddr.of_string host with
+        | Ok ip -> Ipaddr.to_string ip
+        | Error _ -> host)
 
-    let dns_stub_resolver dns service uri : Conduit.endp Lwt.t =
-      let hostn = get_host uri in
-      let port = get_port service uri in
-      (match Ipaddr.V4.of_string hostn with
-      | Ok addr -> Lwt.return (Ok addr)
-      | Error _ -> (
-          match Domain_name.of_string hostn with
-          | Error (`Msg msg) -> Lwt.return (Error (`Msg msg))
-          | Ok domain -> (
-              match Domain_name.host domain with
-              | Error (`Msg msg) -> Lwt.return (Error (`Msg msg))
-              | Ok host -> DNS.gethostbyname dns host)))
-      >|= function
-      | Error (`Msg err) -> `Unknown ("name resolution failed: " ^ err)
-      | Ok addr -> `TCP (Ipaddr.V4 addr, port)
+  let get_port service uri =
+    match Uri.port uri with None -> service.Resolver.port | Some port -> port
 
-    let register ?ns ?(ns_port = 53) ?stack res =
-      (match stack with
-      | Some s ->
-          (* DNS stub resolver *)
-          let nameserver =
-            match ns with None -> None | Some ip -> Some (`TCP, (ip, ns_port))
-          in
-          let dns = DNS.create ?nameserver s in
-          let f = dns_stub_resolver dns in
-          Resolver_lwt.add_rewrite ~host:"" ~f res
-      | None -> ());
-      let service = Resolver_lwt.(service res ++ static_service) in
-      Resolver_lwt.set_service ~f:service res;
-      let vchan_tld = ".xen" in
-      let vchan_res = vchan_resolver ~tld:vchan_tld in
-      Resolver_lwt.add_rewrite ~host:vchan_tld ~f:vchan_res res
+  let static_resolver hosts service uri =
+    let port = get_port service uri in
+    try
+      let fn = Hashtbl.find hosts (get_host uri) in
+      Lwt.return (fn ~port)
+    with Not_found -> Lwt.return (`Unknown "name resolution failed")
 
-    let init ?ns ?ns_port ?stack () =
-      let res = Resolver_lwt.init () in
-      register ?ns ?ns_port ?stack res;
-      res
-  end
+  let static_service name =
+    match Uri_services.tcp_port_of_service name with
+    | [] -> Lwt.return_none
+    | port :: _ ->
+        let tls = is_tls_service name in
+        let svc = { Resolver.name; port; tls } in
+        Lwt.return (Some svc)
+
+  let static hosts =
+    let service = static_service in
+    let rewrites = [ ("", static_resolver hosts) ] in
+    Resolver_lwt.init ~service ~rewrites ()
+
+  let localhost =
+    let hosts = Hashtbl.create 3 in
+    Hashtbl.add hosts "localhost" (fun ~port ->
+        `TCP (Ipaddr.(V4 V4.localhost), port));
+    static hosts
+
+  let vchan_resolver ~tld =
+    let tld_len = String.length tld in
+    let get_short_host uri =
+      let n = get_host uri in
+      let len = String.length n in
+      if len > tld_len && String.sub n (len - tld_len) tld_len = tld then
+        String.sub n 0 (len - tld_len)
+      else n
+    in
+    fun service uri ->
+      (* Strip the tld from the hostname *)
+      let remote_name = get_short_host uri in
+      Printf.printf "vchan_lookup: %s %s -> normalizes to %s\n%!"
+        (Sexplib.Sexp.to_string_hum (Resolver.sexp_of_service service))
+        (Uri.to_string uri) remote_name;
+      Lwt.return (`Vchan_domain_socket (remote_name, service.Resolver.name))
+
+  module DNS = Dns_client_mirage.Make (R) (T) (C) (S)
+
+  let dns_stub_resolver dns service uri : Conduit.endp Lwt.t =
+    let hostn = get_host uri in
+    let port = get_port service uri in
+    (match Ipaddr.V4.of_string hostn with
+    | Ok addr -> Lwt.return (Ok addr)
+    | Error _ -> (
+        match Domain_name.of_string hostn with
+        | Error (`Msg msg) -> Lwt.return (Error (`Msg msg))
+        | Ok domain -> (
+            match Domain_name.host domain with
+            | Error (`Msg msg) -> Lwt.return (Error (`Msg msg))
+            | Ok host -> DNS.gethostbyname dns host)))
+    >|= function
+    | Error (`Msg err) -> `Unknown ("name resolution failed: " ^ err)
+    | Ok addr -> `TCP (Ipaddr.V4 addr, port)
+
+  let register ?ns ?(ns_port = 53) s res =
+    (* DNS stub resolver *)
+    let nameserver =
+      match ns with None -> None | Some ip -> Some (`TCP, (ip, ns_port))
+    in
+    let dns = DNS.create ?nameserver s in
+    let f = dns_stub_resolver dns in
+    Resolver_lwt.add_rewrite ~host:"" ~f res;
+    let service = Resolver_lwt.(service res ++ static_service) in
+    Resolver_lwt.set_service ~f:service res;
+    let vchan_tld = ".xen" in
+    let vchan_res = vchan_resolver ~tld:vchan_tld in
+    Resolver_lwt.add_rewrite ~host:vchan_tld ~f:vchan_res res
+
+  let v ?ns ?ns_port stack =
+    let res = Resolver_lwt.init () in
+    register ?ns ?ns_port stack res;
+    res
+
+  type t = Resolver_lwt.t
 end

--- a/src/conduit-mirage/resolver_mirage.mli
+++ b/src/conduit-mirage/resolver_mirage.mli
@@ -17,27 +17,26 @@
 
 (** Functorial interface for resolving URIs to endpoints. *)
 
-val static : (string, port:int -> Conduit.endp) Hashtbl.t -> Resolver_lwt.t
-(** [static hosts] constructs a resolver that looks up any resolution requests
-    from the static [hosts] hashtable instead of using the system resolver. *)
+module type S = sig
+  include Resolver_lwt.S
 
-val localhost : Resolver_lwt.t
-(** [localhost] is a static resolver that has a single entry that maps
-    [localhost] to [127.0.0.1], and fails on all other hostnames. *)
+  val static : (string, port:int -> Conduit.endp) Hashtbl.t -> t
+  (** [static hosts] constructs a resolver that looks up any resolution requests
+      from the static [hosts] hashtable instead of using the system resolver. *)
 
-(** Provides a DNS-enabled {!Resolver_lwt} given a network stack. See {!Make}. *)
-module Make_with_stack
+  val localhost : t
+  (** [localhost] is a static resolver that has a single entry that maps
+      [localhost] to [127.0.0.1], and fails on all other hostnames. *)
+end
+
+(** Provides a DNS-enabled {!Resolver_lwt} given a network stack. *)
+module Make
     (R : Mirage_random.S)
     (T : Mirage_time.S)
     (C : Mirage_clock.MCLOCK)
     (S : Mirage_stack.V4) : sig
-  include Resolver_lwt.S with type t = Resolver_lwt.t
+  include S
 
-  module R : sig
-    val register :
-      ?ns:Ipaddr.V4.t -> ?ns_port:int -> ?stack:S.t -> Resolver_lwt.t -> unit
-
-    val init : ?ns:Ipaddr.V4.t -> ?ns_port:int -> ?stack:S.t -> unit -> t
-    (** [init ?ns ?ns_port ?stack ()] TODO *)
-  end
+  val v : ?ns:Ipaddr.V4.t -> ?ns_port:int -> S.t -> t
+  (** [v ?ns ?ns_port ?stack ()] TODO *)
 end

--- a/tests/conduit-mirage/http-fetch/unikernel.ml
+++ b/tests/conduit-mirage/http-fetch/unikernel.ml
@@ -14,10 +14,6 @@ module Client (C : CONSOLE) (S : STACKV4) = struct
   module DNS = Dns_resolver_mirage.Make (OS.Time) (S)
   module RES = Resolver_mirage.Make (DNS)
 
-  let mk_conduit s =
-    let stackv4 = Conduit_mirage.stackv4 (module S) in
-    Conduit_mirage.with_tcp Conduit_mirage.empty stackv4 s
-
   let start c stack _ =
     C.log_s c (sprintf "Resolving in 3s using DNS server %s" ns) >>= fun () ->
     OS.Time.sleep 3.0 >>= fun () ->

--- a/tests/conduit-mirage/simple/dune
+++ b/tests/conduit-mirage/simple/dune
@@ -1,4 +1,4 @@
 (test
  (name test)
- (libraries conduit-mirage)
+ (libraries conduit-mirage tcpip.stack-socket)
  (package conduit-mirage))


### PR DESCRIPTION
Do not mix first-class modules and functors anywmore as it makes the
API quite complicated for not much gains: the code is generated by
the mirage tools anyway.

Note: this needs some changes in the mirage tool too. Will do this next if people are generally happy with this simplification.