### PR TITLE
Make listening port discoverable

### DIFF
--- a/src/async-ssl/conduit_async_ssl.ml
+++ b/src/async-ssl/conduit_async_ssl.ml
@@ -302,8 +302,8 @@ module TCP = struct
   let protocol =
     protocol_with_ssl ~reader:Protocol.reader ~writer:Protocol.writer protocol
 
-  let service =
-    service_with_ssl service ~reader:Protocol.reader ~writer:Protocol.writer
+  let service ?listening_on () =
+    service_with_ssl (service ?listening_on ()) ~reader:Protocol.reader ~writer:Protocol.writer
       protocol
 
   let configuration ~context ?backlog listen =

--- a/src/async-ssl/conduit_async_ssl.mli
+++ b/src/async-ssl/conduit_async_ssl.mli
@@ -64,7 +64,7 @@ module TCP : sig
   val protocol : (context * endpoint, Protocol.flow with_ssl) protocol
 
   val service :
-    ?listening_on:[ `Inet of int | `Unix of string ] Ivar.t ->
+    ?listening_on:[ `Inet of int | `Unix of string ] Async.Ivar.t ->
     unit ->
     ( context * Service.configuration,
       context * Service.t,

--- a/src/async-ssl/conduit_async_ssl.mli
+++ b/src/async-ssl/conduit_async_ssl.mli
@@ -64,6 +64,8 @@ module TCP : sig
   val protocol : (context * endpoint, Protocol.flow with_ssl) protocol
 
   val service :
+    ?listening_on:[ `Inet of int | `Unix of string ] Ivar.t ->
+    unit ->
     ( context * Service.configuration,
       context * Service.t,
       Protocol.flow with_ssl )

--- a/src/async-tls/conduit_async_tls.ml
+++ b/src/async-tls/conduit_async_tls.ml
@@ -22,7 +22,8 @@ module TCP = struct
 
   let protocol = protocol_with_tls protocol
 
-  let service = service_with_tls service Conduit_async.TCP.protocol protocol
+  let service ?listening_on () =
+    service_with_tls (service ?listening_on ()) Conduit_async.TCP.protocol protocol
 
   let configuration ~config:tls_config ?backlog listen =
     (configuration ?backlog listen, tls_config)

--- a/src/async-tls/conduit_async_tls.mli
+++ b/src/async-tls/conduit_async_tls.mli
@@ -33,6 +33,8 @@ module TCP : sig
     (endpoint * Tls.Config.client, Protocol.flow protocol_with_tls) protocol
 
   val service :
+    ?listening_on:[ `Inet of int | `Unix of string ] Async.Ivar.t ->
+    unit ->
     ( configuration * Tls.Config.server,
       Service.t service_with_tls,
       Protocol.flow protocol_with_tls )

--- a/src/async/conduit_async.ml
+++ b/src/async/conduit_async.ml
@@ -259,7 +259,7 @@ module TCP = struct
               (match Socket.getsockname socket with
               | `Inet (_, port) -> `Inet port
               | `Unix _ as unix -> unix) |>
-              Ivar.fill listening_on
+              Async.Ivar.fill listening_on
             ) listening_on;
             socket
           in

--- a/src/async/conduit_async.mli
+++ b/src/async/conduit_async.mli
@@ -59,7 +59,10 @@ module TCP : sig
 
   module Service : SERVICE with type configuration = configuration
 
-  val service : (configuration, Service.t, Protocol.flow) service
+  val service :
+    ?listening_on:[ `Inet of int | `Unix of string ] Ivar.t ->
+    unit ->
+    (configuration, Service.t, Protocol.flow) service
 
   val configuration :
     ?backlog:int -> ('a, 'listening_on) Tcp.Where_to_listen.t -> configuration

--- a/src/async/conduit_async.mli
+++ b/src/async/conduit_async.mli
@@ -60,7 +60,7 @@ module TCP : sig
   module Service : SERVICE with type configuration = configuration
 
   val service :
-    ?listening_on:[ `Inet of int | `Unix of string ] Ivar.t ->
+    ?listening_on:[ `Inet of int | `Unix of string ] Async.Ivar.t ->
     unit ->
     (configuration, Service.t, Protocol.flow) service
 


### PR DESCRIPTION
There's currently no way to learn what port a Conduit v3 Async server is listening on. Interrogating a [Tcp.Where_to_listen.t] doesn't always include accurate information, specifically in the special case of [Where_to_listen.of_port_chosen_by_os].

I'd like to propose introducing an optional [listening_on] Ivar.t that will be filled with the relevant port information from the bound [Socket.t] after `main ()` is called.