### PR TITLE
Update conduit-mirage to v4v6

### DIFF
--- a/conduit-lwt-unix.opam
+++ b/conduit-lwt-unix.opam
@@ -25,7 +25,7 @@ depends: [
 ]
 depopts: ["tls" "lwt_ssl" "launchd"]
 conflicts: [
-  "tls" {< "0.11.0"}
+  "tls" {< "0.13.0"}
   "ssl" {< "0.5.9"}
 ]
 build: [
@@ -34,3 +34,7 @@ build: [
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
 synopsis: "A network connection establishment library for Lwt_unix"
+pin-depends: [
+  [ "tls.0.13.0" "git+https://github.com/mirleft/ocaml-tls.git#f9dd61f556d3f2790aa9eedcf2b6b3c8c99cb338" ]
+  [ "tls-mirage.0.13.0" "git+https://github.com/mirleft/ocaml-tls.git#f9dd61f556d3f2790aa9eedcf2b6b3c8c99cb338" ]
+]

--- a/conduit-mirage.opam
+++ b/conduit-mirage.opam
@@ -38,5 +38,8 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name] {with-test}
 ]
+pin-depends: [
+  "dns-client.dev" "git+https://github.com/mirage/ocaml-dns.git#cfec9fe8237d6c4b6e8465f5fbc3781ee0a0b7f5"
+]
 dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
 synopsis: "A network connection establishment library for MirageOS"

--- a/conduit-mirage.opam
+++ b/conduit-mirage.opam
@@ -39,13 +39,11 @@ build: [
   ["dune" "runtest" "-p" name] {with-test}
 ]
 pin-depends: [
-  "dns-client.5.0.0" "git+https://github.com/mirage/ocaml-dns.git#29168a8c464796fda77b50d721176f122ee724ae"
-  "dns.5.0.0" "git+https://github.com/mirage/ocaml-dns.git#29168a8c464796fda77b50d721176f122ee724ae"
-  "x509.0.12.0" "git+https://github.com/mirleft/ocaml-x509.git#02f662eaf7a549ff071a939b86a2e0bfaabc5890"
-]
-dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
-synopsis: "A network connection establishment library for MirageOS"
-pin-depends: [
+  [ "dns-client.5.0.0" "git+https://github.com/mirage/ocaml-dns.git#29168a8c464796fda77b50d721176f122ee724ae" ]
+  [ "dns.5.0.0" "git+https://github.com/mirage/ocaml-dns.git#29168a8c464796fda77b50d721176f122ee724ae" ]
+  [ "x509.0.12.0" "git+https://github.com/mirleft/ocaml-x509.git#02f662eaf7a549ff071a939b86a2e0bfaabc5890" ]
   [ "tls.0.13.0" "git+https://github.com/mirleft/ocaml-tls.git#f9dd61f556d3f2790aa9eedcf2b6b3c8c99cb338" ]
   [ "tls-mirage.0.13.0" "git+https://github.com/mirleft/ocaml-tls.git#f9dd61f556d3f2790aa9eedcf2b6b3c8c99cb338" ]
 ]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library for MirageOS"

--- a/conduit-mirage.opam
+++ b/conduit-mirage.opam
@@ -45,3 +45,7 @@ pin-depends: [
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
 synopsis: "A network connection establishment library for MirageOS"
+pin-depends: [
+  [ "tls.0.13.0" "git+https://github.com/mirleft/ocaml-tls.git#f9dd61f556d3f2790aa9eedcf2b6b3c8c99cb338" ]
+  [ "tls-mirage.0.13.0" "git+https://github.com/mirleft/ocaml-tls.git#f9dd61f556d3f2790aa9eedcf2b6b3c8c99cb338" ]
+]

--- a/conduit-mirage.opam
+++ b/conduit-mirage.opam
@@ -39,7 +39,7 @@ build: [
   ["dune" "runtest" "-p" name] {with-test}
 ]
 pin-depends: [
-  "dns-client" "git+https://github.com/mirage/ocaml-dns.git#cfec9fe8237d6c4b6e8465f5fbc3781ee0a0b7f5"
+  "dns-client.5.0.0" "git+https://github.com/mirage/ocaml-dns.git#29168a8c464796fda77b50d721176f122ee724ae"
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
 synopsis: "A network connection establishment library for MirageOS"

--- a/conduit-mirage.opam
+++ b/conduit-mirage.opam
@@ -41,6 +41,7 @@ build: [
 pin-depends: [
   "dns-client.5.0.0" "git+https://github.com/mirage/ocaml-dns.git#29168a8c464796fda77b50d721176f122ee724ae"
   "dns.5.0.0" "git+https://github.com/mirage/ocaml-dns.git#29168a8c464796fda77b50d721176f122ee724ae"
+  "x509.0.12.0" "git+https://github.com/mirleft/ocaml-x509.git#02f662eaf7a549ff071a939b86a2e0bfaabc5890"
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
 synopsis: "A network connection establishment library for MirageOS"

--- a/conduit-mirage.opam
+++ b/conduit-mirage.opam
@@ -39,7 +39,7 @@ build: [
   ["dune" "runtest" "-p" name] {with-test}
 ]
 pin-depends: [
-  "dns-client.dev" "git+https://github.com/mirage/ocaml-dns.git#cfec9fe8237d6c4b6e8465f5fbc3781ee0a0b7f5"
+  "dns-client" "git+https://github.com/mirage/ocaml-dns.git#cfec9fe8237d6c4b6e8465f5fbc3781ee0a0b7f5"
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
 synopsis: "A network connection establishment library for MirageOS"

--- a/conduit-mirage.opam
+++ b/conduit-mirage.opam
@@ -18,7 +18,7 @@ depends: [
   "mirage-flow-combinators" {>= "2.0.0"}
   "mirage-random" {>= "2.0.0"}
   "mirage-time" {>= "2.0.0"}
-  "dns-client" {>= "4.5.0"}
+  "dns-client" {>= "5.0.0"}
   "conduit-lwt" {=version}
   "vchan" {>= "5.0.0"}
   "xenstore"

--- a/conduit-mirage.opam
+++ b/conduit-mirage.opam
@@ -12,7 +12,7 @@ depends: [
   "sexplib"
   "uri" {>= "4.0.0"}
   "cstruct" {>= "3.0.0"}
-  "mirage-stack" {>= "2.0.0"}
+  "mirage-stack" {>= "2.2.0"}
   "mirage-clock" {>= "3.0.0"}
   "mirage-flow" {>= "2.0.0"}
   "mirage-flow-combinators" {>= "2.0.0"}

--- a/conduit-mirage.opam
+++ b/conduit-mirage.opam
@@ -40,6 +40,7 @@ build: [
 ]
 pin-depends: [
   "dns-client.5.0.0" "git+https://github.com/mirage/ocaml-dns.git#29168a8c464796fda77b50d721176f122ee724ae"
+  "dns.5.0.0" "git+https://github.com/mirage/ocaml-dns.git#29168a8c464796fda77b50d721176f122ee724ae"
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
 synopsis: "A network connection establishment library for MirageOS"

--- a/src/conduit-lwt-unix/conduit_lwt_tls.real.mli
+++ b/src/conduit-lwt-unix/conduit_lwt_tls.real.mli
@@ -18,7 +18,7 @@
 (** TLS/SSL connections via OCaml-TLS *)
 
 module X509 : sig
-  val private_of_pems : cert:string -> priv_key:string -> X509_lwt.priv Lwt.t
+  val private_of_pems : cert:string -> priv_key:string -> Tls.Config.certchain Lwt.t
 
   type authenticator = X509.Authenticator.t
 

--- a/src/conduit-mirage/conduit_mirage.mli
+++ b/src/conduit-mirage/conduit_mirage.mli
@@ -83,8 +83,8 @@ end
 
 (** {2 TCP} *)
 
-module TCP (S : Mirage_stack.V4) :
-  S with type t = S.t and type flow = S.TCPV4.flow
+module TCP (S : Mirage_stack.V4V6) :
+  S with type t = S.t and type flow = S.TCP.flow
 
 (** {2 VCHAN} *)
 

--- a/src/conduit-mirage/resolver_mirage.ml
+++ b/src/conduit-mirage/resolver_mirage.ml
@@ -28,7 +28,7 @@ module Make
     (R : Mirage_random.S)
     (T : Mirage_time.S)
     (C : Mirage_clock.MCLOCK)
-    (S : Mirage_stack.V4) =
+    (S : Mirage_stack.V4V6) =
 struct
   include Resolver_lwt
 

--- a/src/conduit-mirage/resolver_mirage.mli
+++ b/src/conduit-mirage/resolver_mirage.mli
@@ -34,9 +34,9 @@ module Make
     (R : Mirage_random.S)
     (T : Mirage_time.S)
     (C : Mirage_clock.MCLOCK)
-    (S : Mirage_stack.V4) : sig
+    (S : Mirage_stack.V4V6) : sig
   include S
 
-  val v : ?ns:Ipaddr.V4.t -> ?ns_port:int -> S.t -> t
+  val v : ?ns:Ipaddr.t -> ?ns_port:int -> S.t -> t
   (** [v ?ns ?ns_port ?stack ()] TODO *)
 end

--- a/tests/conduit-mirage/simple/test.ml
+++ b/tests/conduit-mirage/simple/test.ml
@@ -5,12 +5,14 @@ let client : Conduit_mirage.client =
 
 let server : Conduit_mirage.server = `TCP 12345
 
-module TCP = Conduit_mirage.TCP (Tcpip_stack_socket.V4)
+module TCP = Conduit_mirage.TCP (Tcpip_stack_socket.V4V6)
 
 let tcp () =
-  Udpv4_socket.connect Ipaddr.V4.Prefix.global >>= fun udp ->
-  Tcpv4_socket.connect Ipaddr.V4.Prefix.global >>= fun tcp ->
-  Tcpip_stack_socket.V4.connect udp tcp
+  let ipv4_only = false and ipv6_only = false in
+  Udpv4v6_socket.connect ~ipv4_only ~ipv6_only Ipaddr.V4.Prefix.global None
+  >>= fun udp ->
+  Tcpv4v6_socket.connect ~ipv4_only ~ipv6_only Ipaddr.V4.Prefix.global None
+  >>= fun tcp -> Tcpip_stack_socket.V4V6.connect udp tcp
 
 let _client () = tcp () >>= fun t -> TCP.connect t client
 


### PR DESCRIPTION
According to the current state of `dns-client` (/cc @hannesm), it's a simple patch to upgrade `conduit` to `v4v6` stack. Currently, we are a bit stuck with: https://github.com/mirage/mirage/pull/1209 which must be merged to upgrade mirage conduit device then to `v4v6`.