### PR TITLE
ipaddr-sexp in conduit-async

### DIFF
--- a/conduit-async.opam
+++ b/conduit-async.opam
@@ -18,6 +18,7 @@ depends: [
   "conduit" {=version}
   "async" {>= "v0.10.0"}
   "ipaddr" {>= "3.0.0"}
+  "ipaddr-sexp" {>= "4.0.0"}
 ]
 depopts: ["async_ssl"]
 conflicts: [

--- a/src/conduit-async/dune
+++ b/src/conduit-async/dune
@@ -7,6 +7,7 @@
  (libraries
   conduit
   async
+  ipaddr-sexp
   ipaddr.unix
   uri.services
   (select


### PR DESCRIPTION
`conduit-async` is missing a dependency on `ipaddr-sexp`.

not sure why this is needed by @sgrove couldn't compile `conduit-async` without it.