### PR TITLE
conduit-lwt-unix: se accept_n on the server

### DIFF
--- a/src/conduit-lwt-unix/conduit_lwt_server.ml
+++ b/src/conduit-lwt-unix/conduit_lwt_server.ml
@@ -71,34 +71,33 @@ let run_handler handler v =
                   f "Uncaught exception in handler: %s" (Printexc.to_string ex)));
           Lwt.return_unit))
 
+let log_exn = function
+  | Some ex ->
+      Log.warn (fun f ->
+          f "Uncaught exception accepting connection: %s"
+            (Printexc.to_string ex))
+  | None -> ()
+
 let init ?(stop = fst (Lwt.wait ())) handler fd =
   let stop = Lwt.map (fun () -> `Stop) stop in
   let rec loop () =
-    Lwt.try_bind
-      (fun () ->
-        connected ();
-        throttle () >>= fun () ->
-        let accept = Lwt.map (fun v -> `Accept v) (Lwt_unix.accept fd) in
-        Lwt.choose [ accept; stop ] >|= function
-        | `Stop ->
-            Lwt.cancel accept;
-            `Stop
-        | `Accept _ as x -> x)
-      (function
-        | `Stop ->
-            disconnected ();
-            Lwt.return_unit
-        | `Accept v ->
+    let accepted =
+      Lwt_unix.accept_n fd 10000 >>= fun (connections, maybe_error) ->
+      log_exn maybe_error;
+      Lwt.return (`Accepted connections)
+    in
+    Lwt.choose [ accepted; stop ] >>= function
+    | `Stop ->
+        Lwt.cancel accepted;
+        Lwt.return_unit
+    | `Accepted connections ->
+        Lwt_list.iter_p
+          (fun v ->
+            connected ();
+            throttle () >>= fun () ->
             run_handler handler v;
-            loop ())
-      (fun exn ->
-        disconnected ();
-        match exn with
-        | Lwt.Canceled -> Lwt.return_unit
-        | ex ->
-            Log.warn (fun f ->
-                f "Uncaught exception accepting connection: %s"
-                  (Printexc.to_string ex));
-            Lwt_unix.yield () >>= loop)
+            Lwt.return_unit)
+          connections
+        >>= fun () -> loop ()
   in
   Lwt.finalize loop (fun () -> Lwt_unix.close fd)

--- a/src/conduit-lwt-unix/conduit_lwt_server.ml
+++ b/src/conduit-lwt-unix/conduit_lwt_server.ml
@@ -71,7 +71,7 @@ let run_handler handler v =
                   f "Uncaught exception in handler: %s" (Printexc.to_string ex)));
           Lwt.return_unit))
 
-let init ?(stop = fst (Lwt.wait ())) handler fd =
+let init ?(nconn=10_000) ?(stop = fst (Lwt.wait ())) handler fd =
   let stop = Lwt.map (fun () -> `Stop) stop in
   let log_exn = function
     | Some ex ->
@@ -82,7 +82,7 @@ let init ?(stop = fst (Lwt.wait ())) handler fd =
   in
   let rec loop () =
     let accepted =
-      Lwt_unix.accept_n fd 10000 >>= fun (connections, maybe_error) ->
+      Lwt_unix.accept_n fd nconn >>= fun (connections, maybe_error) ->
       log_exn maybe_error;
       Lwt.return (`Accepted connections)
     in

--- a/src/conduit-lwt-unix/conduit_lwt_server.ml
+++ b/src/conduit-lwt-unix/conduit_lwt_server.ml
@@ -99,12 +99,12 @@ let init ?(stop = fst (Lwt.wait ())) handler fd =
                 throttle () >>= fun () ->
                 run_handler handler v;
                 Lwt.return_unit)
-              connections)
+              connections
+            >>= fun () -> loop ())
       (function
         | Lwt.Canceled -> Lwt.return_unit
         | ex ->
             log_exn (Some ex);
-            Lwt.return_unit)
-    >>= fun () -> loop ()
+            Lwt.return_unit >>= fun () -> loop ())
   in
   Lwt.finalize loop (fun () -> Lwt_unix.close fd)

--- a/src/conduit-lwt-unix/conduit_lwt_server.mli
+++ b/src/conduit-lwt-unix/conduit_lwt_server.mli
@@ -10,6 +10,7 @@ val process_accept :
   unit Lwt.t
 
 val init :
+  ?nconn:int ->
   ?stop:unit Lwt.t ->
   (Lwt_unix.file_descr * Lwt_unix.sockaddr -> unit Lwt.t) ->
   Lwt_unix.file_descr ->

--- a/src/conduit-lwt-unix/conduit_lwt_server.mli
+++ b/src/conduit-lwt-unix/conduit_lwt_server.mli
@@ -11,6 +11,7 @@ val process_accept :
 
 val init :
   ?stop:unit Lwt.t ->
+  ?nconn:int ->
   (Lwt_unix.file_descr * Lwt_unix.sockaddr -> unit Lwt.t) ->
   Lwt_unix.file_descr ->
   unit Lwt.t

--- a/src/conduit-lwt-unix/conduit_lwt_server.mli
+++ b/src/conduit-lwt-unix/conduit_lwt_server.mli
@@ -11,7 +11,6 @@ val process_accept :
 
 val init :
   ?stop:unit Lwt.t ->
-  ?nconn:int ->
   (Lwt_unix.file_descr * Lwt_unix.sockaddr -> unit Lwt.t) ->
   Lwt_unix.file_descr ->
   unit Lwt.t


### PR DESCRIPTION
In benchmarks for cohttp-lwt-unix' latency we see evidence of connections starvation.
Using `accept_n` seems to improve the situation. You can see [here](https://gist.github.com/mseri/46bee49f50a46267753cfba9d0c24571) an example of the artificial benchmarks that I used to check this

Ping @avsm 