### PR TITLE
Allow openssl conduit-lwt-unix users to control their client Ssl.contexts

### DIFF
--- a/src/conduit-lwt-unix/conduit_lwt_unix.mli
+++ b/src/conduit-lwt-unix/conduit_lwt_unix.mli
@@ -161,16 +161,23 @@ val init :
   ?src:string ->
   ?tls_own_key:tls_own_key ->
   ?tls_authenticator:Conduit_lwt_tls.X509.authenticator ->
+  ?client_ssl_context:Conduit_lwt_unix_ssl.Ssl.context ->
   unit ->
   ctx io
-(** [init ?src ?tls_own_key ()] will initialize a Unix conduit that binds to the
-    [src] interface if specified. If TLS server connections are used, then
-    [tls_server_key] must contain a valid certificate to be used to advertise a
-    TLS connection.
+(** [init ?src ?tls_own_key ?tls_authenticator ?ssl_context ()] will initialize a
+    Unix conduit that binds to the [src] interface if specified. If TLS server
+    connections are used, then [tls_server_key] must contain a valid certificate
+    to be used to advertise a TLS connection.
 
     The certificate is validated using [tls_authenticator]. By default, the
     validation is using the {{:https://github.com/mirage/ca-certs} OS trust
-    anchors}. *)
+    anchors}.
+
+    If the ssl library is used, you can specify your own client SSL context via
+    [client_ssl_context]. If [tls_own_key] is specified, then a new context
+    will be created whenever a new connection is established.  If neither are
+    specified, then [Conduit_lwt_unix_ssl.Client.default_ctx] will be used. You
+    cannot specify both [tls_own_key] and [client_ssl_context]. *)
 
 val connect : ctx:ctx -> client -> (flow * ic * oc) io
 (** [connect ~ctx client] establishes an outgoing connection via the [ctx]

--- a/src/conduit-lwt-unix/conduit_lwt_unix_ssl.dummy.ml
+++ b/src/conduit-lwt-unix/conduit_lwt_unix_ssl.dummy.ml
@@ -15,6 +15,10 @@
  *
  *)
 
+module Ssl = struct
+  type context = unit
+end
+
 module Client = struct
   let default_ctx = `Ssl_not_available
   let create_ctx ?certfile:_ ?keyfile:_ ?password:_ () = default_ctx

--- a/src/conduit-lwt-unix/conduit_lwt_unix_ssl.dummy.mli
+++ b/src/conduit-lwt-unix/conduit_lwt_unix_ssl.dummy.mli
@@ -17,6 +17,10 @@
 
 (** TLS/SSL connections via {{:http://www.openssl.org} OpenSSL} C bindings *)
 
+module Ssl : sig
+  type context = unit
+end
+
 module Client : sig
   val default_ctx : [ `Ssl_not_available ]
 

--- a/src/conduit-lwt-unix/conduit_lwt_unix_ssl.real.ml
+++ b/src/conduit-lwt-unix/conduit_lwt_unix_ssl.real.ml
@@ -19,6 +19,8 @@ open Lwt.Infix
 
 let () = Ssl.init ()
 
+module Ssl = Ssl
+
 let chans_of_fd sock =
   let is_open = ref true in
   let shutdown () =

--- a/src/conduit-lwt-unix/conduit_lwt_unix_ssl.real.mli
+++ b/src/conduit-lwt-unix/conduit_lwt_unix_ssl.real.mli
@@ -17,6 +17,10 @@
 
 (** TLS/SSL connections via {{:http://www.openssl.org} OpenSSL} C bindings *)
 
+module Ssl : sig
+  type context = Ssl.context
+end
+
 module Client : sig
   val default_ctx : Ssl.context
 


### PR DESCRIPTION
I am making this patch because I'd like to be able to control the
lifetime of my openssl client context directly. 

Motivation for this includes the fact that the global
`Conduit_lwt_unix_ssl.Client.default_ctx` is not sufficient in the case
that you want to update an ssl context's verify location (it is
necessary to use a new ssl context).

Example usage with cohttp:

```
(* three types of context :D *)
let client_ssl_context : Ssl.context = Conduit_lwt_unix_ssl.Client.create_ctx () in
(* some ssl setup *)
let* (ctx : Conduit_lwt_unix.ctx) = Conduit_lwt_unix.init ~client_ssl_context () in
let ctx : Cohttp_lwt_unix.Client.ctx = Cohttp_lwt_unix.Client.custom_ctx ~ctx () in
let* _ = Cohttp_lwt_unix.Client.call ~ctx `POST ~body:"blah" uri in
...
```