### PR TITLE
Add openssl_overrides to conduit context

### DIFF
--- a/src/conduit-lwt-unix/conduit_lwt_unix.mli
+++ b/src/conduit-lwt-unix/conduit_lwt_unix.mli
@@ -161,6 +161,7 @@ val init :
   ?src:string ->
   ?tls_own_key:tls_own_key ->
   ?tls_authenticator:Conduit_lwt_tls.X509.authenticator ->
+  ?openssl_overrides:Conduit_lwt_unix_ssl.Overrides.t ->
   unit ->
   ctx io
 (** [init ?src ?tls_own_key ()] will initialize a Unix conduit that binds to the

--- a/src/conduit-lwt-unix/conduit_lwt_unix_ssl.dummy.ml
+++ b/src/conduit-lwt-unix/conduit_lwt_unix_ssl.dummy.ml
@@ -15,6 +15,15 @@
  *
  *)
 
+module Overrides = struct
+  module Client = struct
+    type t = { ctx : [ `Ssl_not_available ] option; hostname : string option }
+  end
+
+  type t = { client : Client.t option }
+end
+
+
 module Client = struct
   let default_ctx = `Ssl_not_available
   let create_ctx ?certfile:_ ?keyfile:_ ?password:_ () = default_ctx

--- a/src/conduit-lwt-unix/conduit_lwt_unix_ssl.dummy.mli
+++ b/src/conduit-lwt-unix/conduit_lwt_unix_ssl.dummy.mli
@@ -17,6 +17,14 @@
 
 (** TLS/SSL connections via {{:http://www.openssl.org} OpenSSL} C bindings *)
 
+module Overrides : sig
+  module Client : sig
+    type t = { ctx : [ `Ssl_not_available ] option; hostname : string option }
+  end
+
+  type t = { client : Client.t option }
+end
+
 module Client : sig
   val default_ctx : [ `Ssl_not_available ]
 

--- a/src/conduit-lwt-unix/conduit_lwt_unix_ssl.real.ml
+++ b/src/conduit-lwt-unix/conduit_lwt_unix_ssl.real.ml
@@ -34,6 +34,14 @@ let chans_of_fd sock =
   let ic = Lwt_io.make ~mode:Lwt_io.input ~close (Lwt_ssl.read_bytes sock) in
   (Lwt_ssl.get_fd sock, ic, oc)
 
+module Overrides = struct
+  module Client = struct
+    type t = { ctx : Ssl.context option; hostname : string option }
+  end
+
+  type t = { client : Client.t option }
+end
+
 module Client = struct
   let create_ctx ?certfile ?keyfile ?password () =
     let ctx = Ssl.create_context Ssl.SSLv23 Ssl.Client_context in

--- a/src/conduit-lwt-unix/conduit_lwt_unix_ssl.real.mli
+++ b/src/conduit-lwt-unix/conduit_lwt_unix_ssl.real.mli
@@ -17,6 +17,14 @@
 
 (** TLS/SSL connections via {{:http://www.openssl.org} OpenSSL} C bindings *)
 
+module Overrides : sig
+  module Client : sig
+    type t = { ctx : Ssl.context option; hostname : string option }
+  end
+
+  type t = { client : Client.t option }
+end
+
 module Client : sig
   val default_ctx : Ssl.context
 


### PR DESCRIPTION
This patch really belongs in cohttp, but I don't think conduit
exposes all the right machinery.

This patch allows openssl cohttp-lwt-unix users to:
(a) connect to a particular hostname/IP, but specify something else to
    verify against
(b) have direct control over the lifetime of their client's ssl context

I believe you should be able to achieve (a) using the following
resolver (but it results in 'not supported' errors):

```
let resolver =
  let table = Hashtbl.create 16 in
  let cn = "expected-cn" in
  let Ok ip = Ipaddr.of_string cn in
  Hashtbl.add table cn (`TLS (cn, `TCP (ip, port)));
  Resolver_lwt_unix.static table
```

It's not possible to achieve (b) right now (at least in v2).

(b) is useful if your trusted bundle changes (calling
`load_verify_locations` with the same SSL context does not work as
one might expect). The alternative is to restart your application.

Intended usage with cohttp:

```
let ctx : Ssl.context = ... in
let openssl_overrides =
  let open Conduit_lwt_unix_ssl.Overrides in
  {
    client =
      Some Client.{ ctx = Some ctx; hostname = Some cn };
  }
in
let* (ctx : Conduit_lwt_unix.ctx) = Conduit_lwt_unix.init ~openssl_overrides () in
let ctx : Cohttp_lwt_unix.Client.ctx = Cohttp_lwt_unix.Client.custom_ctx ~ctx () in
let* _resp, resp_body = Client.call ~ctx `POST ~body uri in
...
```