### PR TITLE
Gitignore `opam/` even if it is a symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 _build/
-_opam/
+_opam
 .*.swp
 *.install
 .merlin


### PR DESCRIPTION
Users of `opam switch link` have an `_opam` directory that is a symlink
to some global switch, which the `opam/` pattern does not match.