### PR TITLE
Lwt_unix.yield was deprecated in favor of Lwt.pause

### DIFF
--- a/src/conduit-lwt-unix/conduit_lwt_server.ml
+++ b/src/conduit-lwt-unix/conduit_lwt_server.ml
@@ -99,6 +99,6 @@ let init ?(stop = fst (Lwt.wait ())) handler fd =
             Log.warn (fun f ->
                 f "Uncaught exception accepting connection: %s"
                   (Printexc.to_string ex));
-            Lwt_unix.yield () >>= loop)
+            Lwt.pause () >>= loop)
   in
   Lwt.finalize loop (fun () -> Lwt_unix.close fd)


### PR DESCRIPTION
Deprecated in the lwt dev, but it's a safe change to make now.