### PR TITLE
continue #395 -- fix compilation in case of tls.dummy is used

### DIFF
--- a/src/conduit-lwt-unix/conduit_lwt_tls.dummy.ml
+++ b/src/conduit-lwt-unix/conduit_lwt_tls.dummy.ml
@@ -3,7 +3,7 @@ module X509 = struct
 
   type authenticator = unit
 
-  let default_authenticator = ()
+  let default_authenticator = lazy ()
 end
 
 module Client = struct

--- a/src/conduit-lwt-unix/conduit_lwt_tls.dummy.mli
+++ b/src/conduit-lwt-unix/conduit_lwt_tls.dummy.mli
@@ -22,7 +22,7 @@ module X509 : sig
 
   type authenticator = unit
 
-  val default_authenticator : authenticator
+  val default_authenticator : authenticator Lazy.t
 end
 
 module Client : sig


### PR DESCRIPTION
the PR #395 was partial - using tls.dummy.ml lead to compilation errors (since Lazy.force was used on a value `()`).

//cc @CraigFe 

~~Also, the `ok_authenticator` was removed -- for common operations client certificates are not required (so the `tls_authenticator` passed to `server` is by default `None`). This makes conduit compatible with recent X509 (& tls) releases 0.15.0 - but still maintain backwards compatibility.~~

the other change above -- tls 0.15.0 compatibility -- was merged into master and released independently of this PR.