### PR TITLE
[Preview] upgrade to ocamlformat.0.20.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,5 +1,4 @@
-version = 0.19.0
+version = 0.20.0
 profile = conventional
 break-infix = fit-or-vertical
 parse-docstrings = true
-module-item-spacing = compact

--- a/tests/conduit-mirage/vchan/config_client.ml
+++ b/tests/conduit-mirage/vchan/config_client.ml
@@ -5,4 +5,5 @@ let main = foreign "Unikernel.Client" (time @-> job)
 let () =
   register
     ~libraries:[ "conduit.mirage"; "vchan.xen" ]
-    ~packages:[ "conduit"; "vchan" ] "vchan_client" [ main $ default_time ]
+    ~packages:[ "conduit"; "vchan" ] "vchan_client"
+    [ main $ default_time ]

--- a/tests/conduit-mirage/vchan/config_server.ml
+++ b/tests/conduit-mirage/vchan/config_server.ml
@@ -5,4 +5,5 @@ let main = foreign "Unikernel.Server" (time @-> job)
 let () =
   register
     ~libraries:[ "conduit.mirage"; "vchan.xen" ]
-    ~packages:[ "conduit"; "vchan" ] "vchan_server" [ main $ default_time ]
+    ~packages:[ "conduit"; "vchan" ] "vchan_server"
+    [ main $ default_time ]


### PR DESCRIPTION
This is a preview of the not-yet-released `ocamlformat.0.20.0`, please wait until the package is published in opam to merge this PR. The output is still likely to slightly change before the package is released.
The changes are due to:
- `module-item-spacing` is now set to `compact` for the default profile
- `module-item-spacing` is now correctly applied to mutually recursive type definitions
- the `.ocamlformat` file has been simplified using the conventional profile
- formatting of list elements has been improved