### PR TITLE
conduit-lwt-unix: set SO_REUSEPORT to true

### DIFF
--- a/src/conduit-lwt-unix/conduit_lwt_server.ml
+++ b/src/conduit-lwt-unix/conduit_lwt_server.ml
@@ -22,6 +22,7 @@ let with_socket sockaddr f =
 let listen ?(backlog = 128) sa =
   with_socket sa (fun fd ->
       Lwt_unix.(setsockopt fd SO_REUSEADDR true);
+      Lwt_unix.(setsockopt fd SO_REUSEPORT true);
       Lwt_unix.bind fd sa >|= fun () ->
       Lwt_unix.listen fd backlog;
       Lwt_unix.set_close_on_exec fd;


### PR DESCRIPTION
Set socket SO_REUSEPORT to true. Sockets with SO_RESUSEPORT set to
true are automatically load balanced by the Linux OS.

This will be especially useful in OCaml 5.0 with multicore support.