### PR TITLE
Preview: upgrade to ocamlformat.0.21.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version = 0.19.0
+version = 0.21.0
 profile = conventional
 break-infix = fit-or-vertical
 parse-docstrings = true

--- a/src/conduit-async/v2.dummy.mli
+++ b/src/conduit-async/v2.dummy.mli
@@ -5,4 +5,4 @@ include
      and type ssl_conn = [ `Ssl_not_compiled_in ]
      and type ssl_opt = [ `Ssl_not_compiled_in ]
      and type allowed_ciphers =
-          [ `Only of string list | `Openssl_default | `Secure ]
+      [ `Only of string list | `Openssl_default | `Secure ]

--- a/src/conduit-async/v2.real.mli
+++ b/src/conduit-async/v2.real.mli
@@ -8,4 +8,4 @@ include
      and type ssl_opt = Ssl.Opt.t
      and type verify_mode = Ssl.Verify_mode.t
      and type allowed_ciphers =
-          [ `Only of string list | `Openssl_default | `Secure ]
+      [ `Only of string list | `Openssl_default | `Secure ]

--- a/src/conduit-async/v3.dummy.mli
+++ b/src/conduit-async/v3.dummy.mli
@@ -5,4 +5,4 @@ include
      and type ssl_conn = [ `Ssl_not_compiled_in ]
      and type ssl_opt = [ `Ssl_not_compiled_in ]
      and type allowed_ciphers =
-          [ `Only of string list | `Openssl_default | `Secure ]
+      [ `Only of string list | `Openssl_default | `Secure ]

--- a/src/conduit-async/v3.real.mli
+++ b/src/conduit-async/v3.real.mli
@@ -8,4 +8,4 @@ include
      and type ssl_opt = Ssl.Opt.t
      and type verify_mode = Ssl.Verify_mode.t
      and type allowed_ciphers =
-          [ `Only of string list | `Openssl_default | `Secure ]
+      [ `Only of string list | `Openssl_default | `Secure ]

--- a/tests/conduit-mirage/vchan/config_client.ml
+++ b/tests/conduit-mirage/vchan/config_client.ml
@@ -5,4 +5,5 @@ let main = foreign "Unikernel.Client" (time @-> job)
 let () =
   register
     ~libraries:[ "conduit.mirage"; "vchan.xen" ]
-    ~packages:[ "conduit"; "vchan" ] "vchan_client" [ main $ default_time ]
+    ~packages:[ "conduit"; "vchan" ] "vchan_client"
+    [ main $ default_time ]

--- a/tests/conduit-mirage/vchan/config_server.ml
+++ b/tests/conduit-mirage/vchan/config_server.ml
@@ -5,4 +5,5 @@ let main = foreign "Unikernel.Server" (time @-> job)
 let () =
   register
     ~libraries:[ "conduit.mirage"; "vchan.xen" ]
-    ~packages:[ "conduit"; "vchan" ] "vchan_server" [ main $ default_time ]
+    ~packages:[ "conduit"; "vchan" ] "vchan_server"
+    [ main $ default_time ]


### PR DESCRIPTION
This is a preview of the formatting of your project codebase with the upcoming `ocamlformat.0.21.0`. Note that this package is not yet released in opam (so the linting/formatting task of your CI won't pass), the formatting might also change slightly in the released version as we try to integrate feedback from our users.

As always, we are happy to hear your feedback!  Thank you for using ocamlformat!