### PR TITLE
conduit-mirage: pass peer name to Tls.Config.client

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        ocaml-version: [ '4.08.1', '4.09.0', '4.10.0', '4.11.1' ]
+        ocaml-version: [ '4.11.2', '4.12.1', '4.13.1', '4.14.0' ]
         operating-system: [ ubuntu-latest ]
     steps:
     - uses: actions/checkout@v2

--- a/conduit-async.opam
+++ b/conduit-async.opam
@@ -10,13 +10,13 @@ bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "2.0"}
-  "core"
+  "core" {>= "v0.15.0"}
   "uri" {>= "4.0.0"}
   "ppx_here" {>= "v0.9.0"}
   "ppx_sexp_conv" {>="v0.13.0"}
   "sexplib"
   "conduit" {=version}
-  "async" {>= "v0.10.0"}
+  "async" {>= "v0.15.0"}
   "ipaddr" {>= "3.0.0"}
   "ipaddr-sexp" {>= "4.0.0"}
 ]

--- a/tests/conduit-async/build.sh
+++ b/tests/conduit-async/build.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-corebuild -tag annot -pkgs conduit.async ssl_echo.native

--- a/tests/conduit-async/dune
+++ b/tests/conduit-async/dune
@@ -1,5 +1,5 @@
 (executable
- (libraries async conduit-async)
+ (libraries async core_unix.command_unix conduit-async)
  (name ssl_echo))
 
 (rule

--- a/tests/conduit-async/ssl_echo.ml
+++ b/tests/conduit-async/ssl_echo.ml
@@ -54,4 +54,4 @@ let () =
       +> flag "-cert-file" (optional string) ~doc:"file Certificate file"
       +> flag "-key-file" (optional string) ~doc:"File Private key file")
     start_server
-  |> Command.run
+  |> Command_unix.run


### PR DESCRIPTION
//cc @palainp this solves the issue you reported at https://github.com/mirleft/ocaml-tls/issues/447 with the http-fetch unikernel.

Dear ocaml-conduit maintainers: what is the proper way to deal with `host` (here being a string) does not conform being a  `` [ `host ] Domain_name.t ``? In this PR, it is silently ignored -- I know not much about conduit and its semantics and usage.