### PR TITLE
Delay parsing of nameservers

### DIFF
--- a/src/conduit-mirage/resolver_mirage.ml
+++ b/src/conduit-mirage/resolver_mirage.ml
@@ -112,8 +112,21 @@ struct
     | Ok addr -> `TCP (Ipaddr.V4 addr, port)
 
   let register ?nameservers s res =
+    let (let*) = Result.bind in
     (* DNS stub resolver *)
-    let nameservers = Option.map (fun ns -> (`Tcp, ns)) nameservers in
+    let* nameservers =
+      Option.fold ~none:(Ok None)
+        ~some:(fun nameservers ->
+            List.fold_left (fun acc ns ->
+                let* acc in
+                let* ns = DNS.nameserver_of_string ns in
+                Ok (ns :: acc))
+              (Ok [])
+              nameservers
+            |> Result.map Option.some)
+        nameservers
+      |> Result.map (Option.map (fun io -> `Tcp, io))
+    in
     let dns = DNS.create ?nameservers s in
     let f = dns_stub_resolver dns in
     Resolver_lwt.add_rewrite ~host:"" ~f res;
@@ -121,12 +134,13 @@ struct
     Resolver_lwt.set_service ~f:service res;
     let vchan_tld = ".xen" in
     let vchan_res = vchan_resolver ~tld:vchan_tld in
-    Resolver_lwt.add_rewrite ~host:vchan_tld ~f:vchan_res res
+    Resolver_lwt.add_rewrite ~host:vchan_tld ~f:vchan_res res;
+    Ok ()
 
   let v ?nameservers stack =
     let res = Resolver_lwt.init () in
-    register ?nameservers stack res;
-    res
+    register ?nameservers stack res
+    |> Result.map (fun () -> res)
 
   type t = Resolver_lwt.t
 end

--- a/src/conduit-mirage/resolver_mirage.ml
+++ b/src/conduit-mirage/resolver_mirage.ml
@@ -112,20 +112,20 @@ struct
     | Ok addr -> `TCP (Ipaddr.V4 addr, port)
 
   let register ?nameservers s res =
-    let (let*) = Result.bind in
+    let ( let* ) = Result.bind in
     (* DNS stub resolver *)
     let* nameservers =
       Option.fold ~none:(Ok None)
         ~some:(fun nameservers ->
-            List.fold_left (fun acc ns ->
-                let* acc = acc in
-                let* ns = DNS.nameserver_of_string ns in
-                Ok (ns :: acc))
-              (Ok [])
-              nameservers
-            |> Result.map Option.some)
+          List.fold_left
+            (fun acc ns ->
+              let* acc = acc in
+              let* ns = DNS.nameserver_of_string ns in
+              Ok (ns :: acc))
+            (Ok []) nameservers
+          |> Result.map Option.some)
         nameservers
-      |> Result.map (Option.map (fun io -> `Tcp, io))
+      |> Result.map (Option.map (fun io -> (`Tcp, io)))
     in
     let dns = DNS.create ?nameservers s in
     let f = dns_stub_resolver dns in
@@ -139,8 +139,7 @@ struct
 
   let v ?nameservers stack =
     let res = Resolver_lwt.init () in
-    register ?nameservers stack res
-    |> Result.map (fun () -> res)
+    register ?nameservers stack res |> Result.map (fun () -> res)
 
   type t = Resolver_lwt.t
 end

--- a/src/conduit-mirage/resolver_mirage.ml
+++ b/src/conduit-mirage/resolver_mirage.ml
@@ -118,7 +118,7 @@ struct
       Option.fold ~none:(Ok None)
         ~some:(fun nameservers ->
             List.fold_left (fun acc ns ->
-                let* acc in
+                let* acc = acc in
                 let* ns = DNS.nameserver_of_string ns in
                 Ok (ns :: acc))
               (Ok [])

--- a/src/conduit-mirage/resolver_mirage.mli
+++ b/src/conduit-mirage/resolver_mirage.mli
@@ -38,10 +38,7 @@ module Make
     (S : Tcpip.Stack.V4V6) : sig
   include S
 
-  val v :
-    ?nameservers:string list ->
-    S.t ->
-    (t, [> `Msg of string ]) result
+  val v : ?nameservers:string list -> S.t -> (t, [> `Msg of string ]) result
   (** [v ~nameservers stack ()] TODO. An error is returned if any of the
       nameserver specifications do not parse. *)
 end

--- a/src/conduit-mirage/resolver_mirage.mli
+++ b/src/conduit-mirage/resolver_mirage.mli
@@ -39,11 +39,9 @@ module Make
   include S
 
   val v :
-    ?nameservers:
-      [ `Plaintext of Ipaddr.t * int
-      | `Tls of Tls.Config.client * Ipaddr.t * int ]
-      list ->
+    ?nameservers:string list ->
     S.t ->
-    t
-  (** [v ~nameservers stack ()] TODO *)
+    (t, [> `Msg of string ]) result
+  (** [v ~nameservers stack ()] TODO. An error is returned if any of the
+      nameserver specifications do not parse. *)
 end


### PR DESCRIPTION
If we want to use TLS we need to be able to create an authenticator. And many interesting authenticators require ca-certs.