### PR TITLE
conduit-lwt-unix: update to tls 0.16 package (now it is tls-lwt, no more tls.lwt)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## v6.2.0 (2023-02-17)
+
+* conduit-lwt-unix: adapt tls 0.16 split: tls.lwt is now tls-lwt (#419 @hannesm)
+* conduit-mirage: adapt dns-client 7.0.0 split: dns-client-mirage (#419 @hannesm)
+
 ## v6.1.0 (2022-12-15)
 
 done by @psafont in #417:

--- a/conduit-lwt-unix.opam
+++ b/conduit-lwt-unix.opam
@@ -23,9 +23,9 @@ depends: [
   "ssl" {with-test}
   "lwt_ssl" {with-test}
 ]
-depopts: ["tls" "lwt_ssl" "launchd"]
+depopts: ["tls-lwt" "lwt_ssl" "launchd"]
 conflicts: [
-  "tls" {< "0.14.0"}
+  "tls-lwt" {< "0.16.0"}
   "ssl" {< "0.5.12"}
 ]
 build: [

--- a/conduit-mirage.opam
+++ b/conduit-mirage.opam
@@ -17,7 +17,7 @@ depends: [
   "mirage-flow-combinators" {>= "2.0.0"}
   "mirage-random" {>= "2.0.0"}
   "mirage-time" {>= "2.0.0"}
-  "dns-client" {>= "6.4.0"}
+  "dns-client-mirage" {>= "7.0.0"}
   "conduit-lwt" {=version}
   "vchan" {>= "5.0.0"}
   "xenstore"

--- a/src/conduit-lwt-unix/dune
+++ b/src/conduit-lwt-unix/dune
@@ -31,10 +31,10 @@
   (select
    conduit_lwt_tls.ml
    from
-   (tls.lwt ca-certs -> conduit_lwt_tls.real.ml)
+   (tls-lwt ca-certs -> conduit_lwt_tls.real.ml)
    (-> conduit_lwt_tls.dummy.ml))
   (select
    conduit_lwt_tls.mli
    from
-   (tls.lwt ca-certs -> conduit_lwt_tls.real.mli)
+   (tls-lwt ca-certs -> conduit_lwt_tls.real.mli)
    (-> conduit_lwt_tls.dummy.mli))))

--- a/src/conduit-mirage/dune
+++ b/src/conduit-mirage/dune
@@ -6,5 +6,5 @@
  (modules conduit_mirage resolver_mirage conduit_xenstore)
  (wrapped false)
  (libraries conduit conduit-lwt tcpip mirage-clock mirage-random mirage-time
-   mirage-flow mirage-flow-combinators dns-client.mirage ipaddr-sexp vchan
+   mirage-flow mirage-flow-combinators dns-client-mirage ipaddr-sexp vchan
    tls tls-mirage xenstore.client uri.services ca-certs-nss fmt))


### PR DESCRIPTION
conduit-mirage: update to dns-client 7.0.0 package (dns-client-mirage instead of dns-client.mirage)