### PR TITLE
conduit-mirage: adapt to tls 0.17.0 which does no longer provide S-expressions

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version = 0.23.0
+version = 0.26.1
 profile = conventional
 break-infix = fit-or-vertical
 parse-docstrings = true

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## v6.2.1 (2023-11-28)
+
+This is only a conduit-mirage release
+
+* conduit-mirage: adapt to tls 0.17.0 API changes (no more sexplib converters)
+  #421 @hannesm
+
 ## v6.2.0 (2023-02-17)
 
 * conduit-lwt-unix: adapt tls 0.16 split: tls.lwt is now tls-lwt (#419 @hannesm)

--- a/src/conduit-lwt-unix/conduit_lwt_unix.mli
+++ b/src/conduit-lwt-unix/conduit_lwt_unix.mli
@@ -16,8 +16,8 @@
  *
  *)
 
-(** Connection establishment using the {{:http://ocsigen.org/lwt/api/Lwt_unix}
-    Lwt_unix} library *)
+(** Connection establishment using the
+    {{:http://ocsigen.org/lwt/api/Lwt_unix} Lwt_unix} library *)
 
 (** {2 Core types} *)
 
@@ -171,8 +171,8 @@ val init :
     If TLS server connections are used, then [tls_own_key] must contain a valid
     certificate to be used to advertise a TLS connection. In TLS mode the
     certificate is validated using [tls_authenticator]. By default, the
-    validation is using the {{:https://github.com/mirage/ca-certs} OS trust
-    anchors}.
+    validation is using the
+    {{:https://github.com/mirage/ca-certs} OS trust anchors}.
 
     If SSL client connections are used, then [tls_own_key] may contain a valid
     certificate to be used to advertise a TLS connection. If it's not configured

--- a/src/conduit-mirage/conduit_mirage.ml
+++ b/src/conduit-mirage/conduit_mirage.ml
@@ -38,9 +38,23 @@ let err_not_supported = function
   | `TCP _ -> err_tcp_not_supported
   | `Vchan _ -> err_vchan_not_supported
 
+module Tls_config = struct
+  type client = Tls.Config.client
+  let sexp_of_client _ =
+    failwith "converting a TLS client config into S-Expression not supported"
+  let client_of_sexp _ =
+    failwith "converting a S-Expression into a TLS client config not supported"
+
+  type server = Tls.Config.server
+  let sexp_of_server _ =
+    failwith "converting a TLS server config into S-Expression not supported"
+  let server_of_sexp _ =
+    failwith "converting a S-Expression into a TLS server config not supported"
+end
+
 type client =
   [ `TCP of Ipaddr_sexp.t * int
-  | `TLS of Tls.Config.client * client
+  | `TLS of Tls_config.client * client
   | `Vchan of
     [ `Direct of int * Vchan.Port.t | `Domain_socket of string * Vchan.Port.t ]
   ]
@@ -48,7 +62,7 @@ type client =
 
 type server =
   [ `TCP of int
-  | `TLS of Tls.Config.server * server
+  | `TLS of Tls_config.server * server
   | `Vchan of [ `Direct of int * Vchan.Port.t | `Domain_socket ] ]
 [@@deriving sexp]
 

--- a/src/conduit-mirage/conduit_mirage.ml
+++ b/src/conduit-mirage/conduit_mirage.ml
@@ -40,14 +40,18 @@ let err_not_supported = function
 
 module Tls_config = struct
   type client = Tls.Config.client
+
   let sexp_of_client _ =
     failwith "converting a TLS client config into S-Expression not supported"
+
   let client_of_sexp _ =
     failwith "converting a S-Expression into a TLS client config not supported"
 
   type server = Tls.Config.server
+
   let sexp_of_server _ =
     failwith "converting a TLS server config into S-Expression not supported"
+
   let server_of_sexp _ =
     failwith "converting a S-Expression into a TLS server config not supported"
 end

--- a/src/conduit-mirage/conduit_mirage.mli
+++ b/src/conduit-mirage/conduit_mirage.mli
@@ -42,7 +42,7 @@ module Endpoint (P : Mirage_clock.PCLOCK) : sig
   val nss_authenticator : X509.Authenticator.t
   (** [nss_authenticator] is the validator using the
       {{:https://github.com/mirage/ca-certs-nss} trust anchors extracted from
-      Mozilla's NSS}. *)
+        Mozilla's NSS}. *)
 
   val client :
     ?tls_authenticator:X509.Authenticator.t -> Conduit.endp -> client Lwt.t


### PR DESCRIPTION
Since tls 0.13.1 the client/server_of_sexp result in an invalid argument (https://github.com/mirleft/ocaml-tls/commit/a1fc37efaedbcbec89874ca746cde69b2950f0f6) -- which has never been reported anywhere, so I wonder whether anyone is using these things.

If the answer is no, we could as well remove the `deriving sexp` from conduit. But since I don't use this package anymore, I'm not too excited about modifying it.