### PR TITLE
Switch to sexplib0 for lighter dependencies

### DIFF
--- a/conduit-async.opam
+++ b/conduit-async.opam
@@ -14,7 +14,7 @@ depends: [
   "uri" {>= "4.0.0"}
   "ppx_here" {>= "v0.9.0"}
   "ppx_sexp_conv" {>="v0.13.0"}
-  "sexplib"
+  "sexplib0"
   "conduit" {=version}
   "async" {>= "v0.15.0"}
   "ipaddr" {>= "3.0.0"}

--- a/conduit-lwt.opam
+++ b/conduit-lwt.opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "2.0"}
   "base-unix"
   "ppx_sexp_conv" {>="v0.13.0"}
-  "sexplib"
+  "sexplib0"
   "conduit" {=version}
   "lwt" {>= "3.0.0"}
 ]

--- a/conduit-mirage.opam
+++ b/conduit-mirage.opam
@@ -9,7 +9,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.0"}
   "ppx_sexp_conv" {>="v0.13.0"}
-  "sexplib"
+  "sexplib0"
   "uri" {>= "4.0.0"}
   "cstruct" {>= "3.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/conduit.opam
+++ b/conduit.opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.0"}
   "ppx_sexp_conv" {>="v0.13.0"}
-  "sexplib"
+  "sexplib0"
   "astring"
   "uri"
   "logs" {>= "0.5.0"}

--- a/src/conduit-lwt-unix/conduit_lwt_unix.ml
+++ b/src/conduit-lwt-unix/conduit_lwt_unix.ml
@@ -17,7 +17,7 @@
  *)
 
 open Lwt.Infix
-open Sexplib.Conv
+open Sexplib0.Sexp_conv
 
 let debug = ref false
 let debug_print = ref Printf.eprintf
@@ -49,7 +49,7 @@ let tls_library = ref default_tls_library
 let () =
   if !debug then
     !debug_print "Selected TLS library: %s\n"
-      (Sexplib.Sexp.to_string (sexp_of_tls_lib !tls_library))
+      (Sexplib0.Sexp.to_string (sexp_of_tls_lib !tls_library))
 
 type +'a io = 'a Lwt.t
 type ic = Lwt_io.input_channel
@@ -429,7 +429,7 @@ let endp_to_client ~ctx:_ (endp : Conduit.endp) : client Lwt.t =
       Lwt.fail_with
         (Printf.sprintf "TLS to non-TCP currently unsupported: host=%s endp=%s"
            host
-           (Sexplib.Sexp.to_string_hum (Conduit.sexp_of_endp endp)))
+           (Sexplib0.Sexp.to_string_hum (Conduit.sexp_of_endp endp)))
   | `Unknown err -> Lwt.fail_with ("resolution failed: " ^ err)
 
 let endp_to_server ~ctx (endp : Conduit.endp) =

--- a/src/conduit-lwt-unix/resolver_lwt_unix.ml
+++ b/src/conduit-lwt-unix/resolver_lwt_unix.ml
@@ -29,8 +29,8 @@ let () =
 let return_endp name svc uri endp =
   if !debug then
     !debug_print "Resolver %s: %s %s -> %s\n%!" name (Uri.to_string uri)
-      (Sexplib.Sexp.to_string_hum (Resolver.sexp_of_service svc))
-      (Sexplib.Sexp.to_string_hum (Conduit.sexp_of_endp endp));
+      (Sexplib0.Sexp.to_string_hum (Resolver.sexp_of_service svc))
+      (Sexplib0.Sexp.to_string_hum (Conduit.sexp_of_endp endp));
   Lwt.return endp
 
 let is_tls_service =

--- a/src/conduit-mirage/conduit_mirage.ml
+++ b/src/conduit-mirage/conduit_mirage.ml
@@ -19,7 +19,7 @@
 let src = Logs.Src.create "conduit_mirage" ~doc:"Conduit Mirage"
 
 module Log = (val Logs.src_log src : Logs.LOG)
-open Sexplib.Conv
+open Sexplib0.Sexp_conv
 
 let ( >>= ) = Lwt.( >>= )
 let ( >|= ) = Lwt.( >|= )

--- a/src/conduit-mirage/conduit_xenstore.ml
+++ b/src/conduit-mirage/conduit_xenstore.ml
@@ -16,7 +16,7 @@
  *
  *)
 
-open Sexplib.Conv
+open Sexplib0.Sexp_conv
 
 type direct = [ `Direct of int * Vchan.Port.t ]
 

--- a/src/conduit-mirage/resolver_mirage.ml
+++ b/src/conduit-mirage/resolver_mirage.ml
@@ -89,7 +89,7 @@ struct
       (* Strip the tld from the hostname *)
       let remote_name = get_short_host uri in
       Printf.printf "vchan_lookup: %s %s -> normalizes to %s\n%!"
-        (Sexplib.Sexp.to_string_hum (Resolver.sexp_of_service service))
+        (Sexplib0.Sexp.to_string_hum (Resolver.sexp_of_service service))
         (Uri.to_string uri) remote_name;
       Lwt.return (`Vchan_domain_socket (remote_name, service.Resolver.name))
 

--- a/src/conduit/conduit.ml
+++ b/src/conduit/conduit.ml
@@ -15,7 +15,7 @@
  *
  *)
 
-open Sexplib.Std
+open Sexplib0.Sexp_conv
 
 type endp =
   [ `TCP of Ipaddr_sexp.t * int  (** ipaddr and dst port *)

--- a/src/conduit/conduit_trie.ml
+++ b/src/conduit/conduit_trie.ml
@@ -16,7 +16,7 @@
  *
  *)
 
-open Sexplib.Std
+open Sexplib0.Sexp_conv
 
 type 'a t = Node of string * 'a option * 'a t list [@@deriving sexp]
 

--- a/src/conduit/dune
+++ b/src/conduit/dune
@@ -5,7 +5,7 @@
  (preprocess
   (pps ppx_sexp_conv))
  (modules conduit conduit_trie resolver)
- (libraries sexplib ipaddr ipaddr-sexp uri astring))
+ (libraries sexplib0 ipaddr ipaddr-sexp uri astring))
 
 (documentation
  (package conduit))

--- a/src/conduit/resolver.ml
+++ b/src/conduit/resolver.ml
@@ -15,7 +15,7 @@
  *
  *)
 
-open Sexplib.Std
+open Sexplib0.Sexp_conv
 open Astring
 
 type service = { name : string; port : int; tls : bool } [@@deriving sexp]


### PR DESCRIPTION
`sexplib0` only depends on `ocaml` and `dune`. It contains the type definition and some conversion functions. `conduit` does not use anything else (like a parser, etc) so it can use it.
(`sexplib` already depends on `sexplib0` so it's using the same types under the hood)

The corresponding bits are:
- `sexplib` (opam package and library) -> `sexplib0`
- `Sexplib.Conv` (module) -> `Sexplib0.Sexp_conv`
- `Sexplib.Std` -> `Sexplib0.Sexp_conv` (we only need these bits)
- `Sexplib.Sexp.to_string_hum` -> `Sexplib0.Sexp.to_string_hum`
