### PR TITLE
TLS tunnel over Lwt_io.channel

### DIFF
--- a/src/conduit-lwt-unix/conduit_lwt_tls.dummy.ml
+++ b/src/conduit-lwt-unix/conduit_lwt_tls.dummy.ml
@@ -9,6 +9,9 @@ end
 module Client = struct
   let connect ?src:_ ?certificates:_ ~authenticator:_ _host _sa =
     failwith "Tls not available"
+
+  let tunnel ?certificates:_ ~authenticator:_ _host _ioc =
+    failwith "Tls not available"
 end
 
 module Server = struct

--- a/src/conduit-lwt-unix/conduit_lwt_tls.dummy.mli
+++ b/src/conduit-lwt-unix/conduit_lwt_tls.dummy.mli
@@ -33,6 +33,13 @@ module Client : sig
     [ `host ] Domain_name.t ->
     Lwt_unix.sockaddr ->
     (Lwt_unix.file_descr * Lwt_io.input_channel * Lwt_io.output_channel) Lwt.t
+
+  val tunnel :
+    ?certificates:'a ->
+    authenticator:X509.authenticator ->
+    [ `host ] Domain_name.t ->
+    Lwt_io.input_channel * Lwt_io.output_channel ->
+    (Lwt_io.input_channel * Lwt_io.output_channel) Lwt.t
 end
 
 module Server : sig

--- a/src/conduit-lwt-unix/conduit_lwt_tls.real.mli
+++ b/src/conduit-lwt-unix/conduit_lwt_tls.real.mli
@@ -34,6 +34,13 @@ module Client : sig
     [ `host ] Domain_name.t ->
     Lwt_unix.sockaddr ->
     (Lwt_unix.file_descr * Lwt_io.input_channel * Lwt_io.output_channel) Lwt.t
+
+  val tunnel :
+    ?certificates:Tls.Config.own_cert ->
+    authenticator:X509.authenticator ->
+    [ `host ] Domain_name.t ->
+    Lwt_io.input_channel * Lwt_io.output_channel ->
+    (Lwt_io.input_channel * Lwt_io.output_channel) Lwt.t
 end
 
 module Server : sig

--- a/src/conduit-lwt-unix/conduit_lwt_unix.ml
+++ b/src/conduit-lwt-unix/conduit_lwt_unix.ml
@@ -276,11 +276,12 @@ let certificates ~ctx =
 let domain_name hostname =
   try Domain_name.(host_exn (of_string_exn hostname))
   with Invalid_argument msg ->
-    let s =
+    let trace = Printexc.get_raw_backtrace () in
+    let msg =
       Printf.sprintf "couldn't convert %s to a [`host] Domain_name.t: %s"
         hostname msg
     in
-    invalid_arg s
+    Printexc.raise_with_backtrace (Invalid_argument msg) trace
 
 let connect_with_tls_native ~ctx (`Hostname hostname, `IP ip, `Port port) =
   let sa = Unix.ADDR_INET (Ipaddr_unix.to_inet_addr ip, port) in

--- a/src/conduit-lwt-unix/conduit_lwt_unix.mli
+++ b/src/conduit-lwt-unix/conduit_lwt_unix.mli
@@ -28,6 +28,8 @@ type client_tls_config =
 
 type client =
   [ `TLS of client_tls_config
+  | `TLS_tunnel of
+    [ `Hostname of string ] * Lwt_io.input_channel * Lwt_io.output_channel
   | `TLS_native of client_tls_config
     (** Force use of native OCaml TLS stack to connect.*)
   | `OpenSSL of client_tls_config
@@ -104,8 +106,8 @@ type server =
       documentation for more. *)
 
 type 'a io = 'a Lwt.t
-type ic = Lwt_io.input_channel
-type oc = Lwt_io.output_channel
+type ic = (Lwt_io.input_channel[@sexp.opaque]) [@@deriving sexp]
+type oc = (Lwt_io.output_channel[@sexp.opaque]) [@@deriving sexp]
 
 type tcp_flow = private {
   fd : Lwt_unix.file_descr; [@sexp.opaque]
@@ -129,6 +131,7 @@ type vchan_flow = private { domid : int; port : string } [@@deriving sexp_of]
     transport method. *)
 type flow = private
   | TCP of tcp_flow
+  | Tunnel
   | Domain_socket of domain_flow
   | Vchan of vchan_flow
 [@@deriving sexp_of]

--- a/src/conduit-lwt-unix/conduit_lwt_unix.mli
+++ b/src/conduit-lwt-unix/conduit_lwt_unix.mli
@@ -26,10 +26,13 @@ type client_tls_config =
 [@@deriving sexp]
 (** Configuration fragment for a TLS client connecting to a remote endpoint *)
 
+type 'a io = 'a Lwt.t
+type ic = (Lwt_io.input_channel[@sexp.opaque]) [@@deriving sexp]
+type oc = (Lwt_io.output_channel[@sexp.opaque]) [@@deriving sexp]
+
 type client =
   [ `TLS of client_tls_config
-  | `TLS_tunnel of
-    [ `Hostname of string ] * Lwt_io.input_channel * Lwt_io.output_channel
+  | `TLS_tunnel of [ `Hostname of string ] * ic * oc
   | `TLS_native of client_tls_config
     (** Force use of native OCaml TLS stack to connect.*)
   | `OpenSSL of client_tls_config
@@ -105,10 +108,6 @@ type server =
       the {{:http://mirage.github.io/ocaml-launchd/launchd/} ocaml-launchd}
       documentation for more. *)
 
-type 'a io = 'a Lwt.t
-type ic = (Lwt_io.input_channel[@sexp.opaque]) [@@deriving sexp]
-type oc = (Lwt_io.output_channel[@sexp.opaque]) [@@deriving sexp]
-
 type tcp_flow = private {
   fd : Lwt_unix.file_descr; [@sexp.opaque]
   ip : Ipaddr.t;
@@ -131,7 +130,7 @@ type vchan_flow = private { domid : int; port : string } [@@deriving sexp_of]
     transport method. *)
 type flow = private
   | TCP of tcp_flow
-  | Tunnel
+  | Tunnel of string * ic * oc
   | Domain_socket of domain_flow
   | Vchan of vchan_flow
 [@@deriving sexp_of]
@@ -207,11 +206,18 @@ val set_max_active : int -> unit
     accepted. When the limit is hit accept blocks until another server
     connection is closed. *)
 
-val endp_of_flow : flow -> Conduit.endp
-(** [endp_of_flow flow] retrieves the original {!Conduit.endp} from the
-    established [flow] *)
+type endp =
+  [ Conduit.endp
+  | `TLS_tunnel of string * ic * oc
+    (** Wrap in a TLS channel over an existing [Lwt_io.channel] connection,
+        [hostname,input_channel,output_channel] *) ]
+[@@deriving sexp]
 
-val endp_to_client : ctx:ctx -> Conduit.endp -> client io
+val endp_of_flow : flow -> endp
+(** [endp_of_flow flow] retrieves the original {!endp} from the established
+    [flow] *)
+
+val endp_to_client : ctx:ctx -> [< endp ] -> client io
 (** [endp_to_client ~ctx endp] converts an [endp] into a a concrete connection
     mechanism of type [client] *)
 

--- a/tests/conduit-lwt-unix/dune
+++ b/tests/conduit-lwt-unix/dune
@@ -1,6 +1,6 @@
 (executables
  (libraries lwt_ssl ssl conduit-lwt-unix lwt_log)
- (names cdtest cdtest_tls exit_test))
+ (names cdtest cdtest_tls exit_test tls_over_tls))
 
 (rule
  (alias runtest)

--- a/tests/conduit-lwt-unix/tls_over_tls.ml
+++ b/tests/conduit-lwt-unix/tls_over_tls.ml
@@ -1,0 +1,61 @@
+open Lwt.Infix
+
+let hostname = "mirage.io"
+
+(* To test TLS-over-TLS, the `squid` proxy can be installed locally and configured to support HTTPS:
+
+   - Generate a certificate for localhost: https://gist.github.com/cecilemuller/9492b848eb8fe46d462abeb26656c4f8
+
+   $ openssl req -x509 -nodes -new -sha256 -days 1024 -newkey rsa:2048 -keyout RootCA.key -out RootCA.pem -subj "/C=US/CN=Example-Root-CA"
+   $ openssl x509 -outform pem -in RootCA.pem -out RootCA.crt
+   $ cat > domains.ext
+   authorityKeyIdentifier=keyid,issuer
+   basicConstraints=CA:FALSE
+   keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+   subjectAltName = @alt_names
+   [alt_names]
+   DNS.1 = localhost
+   $ openssl req -new -nodes -newkey rsa:2048 -keyout localhost.key -out localhost.csr -subj "/C=US/ST=YourState/L=YourCity/O=Example-Certificates/CN=localhost.local"
+   $ openssl x509 -req -sha256 -days 1024 -in localhost.csr -CA RootCA.pem -CAkey RootCA.key -CAcreateserial -extfile domains.ext -out localhost.crt
+
+   - Configure squid by adding HTTPS support on port 3129 in /etc/squid/squid.conf :
+
+   https_port 3129 tls-cert=/path/to/localhost.crt tls-key=/path/to/localhost.key
+*)
+
+let proxy =
+  `TLS
+    (`Hostname "localhost", `IP (Ipaddr.of_string_exn "127.0.0.1"), `Port 3129)
+
+let string_prefix ~prefix msg =
+  let len = String.length prefix in
+  String.length msg >= len && String.sub msg 0 len = prefix
+
+let main () =
+  let ctx = Lazy.force Conduit_lwt_unix.default_ctx in
+  Conduit_lwt_unix.connect ~ctx proxy >>= fun (_flow, ic, oc) ->
+  let req =
+    String.concat "\r\n"
+      [ "CONNECT " ^ hostname ^ ":443 HTTP/1.1"; "Host: " ^ hostname; ""; "" ]
+  in
+  Lwt_io.write oc req >>= fun () ->
+  let rec try_read () =
+    Lwt_io.read ic ~count:1024 >>= fun msg ->
+    if msg = "" then try_read () else Lwt.return msg
+  in
+  try_read () >>= fun msg ->
+  assert (string_prefix ~prefix:"HTTP/1.1 200 " msg);
+
+  (* We are now connected to mirage.io:443 through the proxy *)
+  let client = `TLS_tunnel (`Hostname hostname, ic, oc) in
+  Conduit_lwt_unix.connect ~ctx client >>= fun (_flow, ic, oc) ->
+  let req =
+    String.concat "\r\n" [ "GET / HTTP/1.1"; "Host: " ^ hostname; ""; "" ]
+  in
+  Lwt_io.write oc req >>= fun () ->
+  Lwt_io.read ic ~count:4096 >>= fun msg ->
+  Lwt_io.print msg >>= fun () ->
+  Lwt_io.read ic ~count:4096 >>= fun msg ->
+  Lwt_io.print msg >>= fun () -> Lwt_io.print "\n"
+
+let () = Lwt_main.run (main ())


### PR DESCRIPTION
I'm marking this PR as a draft, because it exposes the functionalities of TLS-over-TLS added by this PR https://github.com/mirleft/ocaml-tls/pull/499 which hasn't yet been reviewed... but I have some questions on how to best present this feature in Conduit :)

For context, @MisterDA has a working implementation of `cohttp-lwt-unix` client requests with http/https proxying, which relies on `conduit-lwt-unix` for TLS and on this PR for the "https over http(s)", which happens because https proxies provide a safe tunnel for the client to negotiate the TLS connection with the server. For this to work though, we need to able to reuse an existing connection instead of having Conduit create a new socket. The https://github.com/mirleft/ocaml-tls/pull/499 PR has more details on how this works, but I've also added an example in Conduit to test the flow if you are curious.