### PR TITLE
Raise and reraise exceptions with `Stdlib` rather than `Lwt`.

### DIFF
--- a/src/conduit-lwt-unix/conduit_lwt_launchd.dummy.ml
+++ b/src/conduit-lwt-unix/conduit_lwt_launchd.dummy.ml
@@ -15,4 +15,4 @@
  *
  *)
 
-let activate _fn _name = Lwt.fail_with "No Launchd support"
+let activate _fn _name = failwith "No Launchd support"

--- a/src/conduit-lwt-unix/conduit_lwt_launchd.real.ml
+++ b/src/conduit-lwt-unix/conduit_lwt_launchd.real.ml
@@ -21,4 +21,4 @@ let activate fn name =
   Lwt_launchd.activate_socket name >>= fun sockets ->
   match Launchd.error_to_msg sockets with
   | Ok sockets -> Lwt_list.iter_p fn sockets
-  | Error (`Msg m) -> Lwt.fail_with m
+  | Error (`Msg m) -> failwith m

--- a/src/conduit-lwt-unix/conduit_lwt_server.ml
+++ b/src/conduit-lwt-unix/conduit_lwt_server.ml
@@ -17,7 +17,7 @@ let with_socket sockaddr f =
     (fun () -> f fd)
     (fun e ->
       Lwt.catch (fun () -> Lwt_unix.close fd) (fun _ -> Lwt.return_unit)
-      >>= fun () -> Lwt.fail e)
+      >>= fun () -> Lwt.reraise e)
 
 let listen ?(backlog = 128) sa =
   with_socket sa (fun fd ->

--- a/src/conduit-lwt-unix/conduit_lwt_tls.dummy.ml
+++ b/src/conduit-lwt-unix/conduit_lwt_tls.dummy.ml
@@ -1,5 +1,5 @@
 module X509 = struct
-  let private_of_pems ~cert:_ ~priv_key:_ = Lwt.fail_with "Tls not available"
+  let private_of_pems ~cert:_ ~priv_key:_ = failwith "Tls not available"
 
   type authenticator = unit
 
@@ -8,15 +8,15 @@ end
 
 module Client = struct
   let connect ?src:_ ?certificates:_ ~authenticator:_ _host _sa =
-    Lwt.fail_with "Tls not available"
+    failwith "Tls not available"
 end
 
 module Server = struct
   let init' ?backlog:_ ?stop:_ ?timeout:_ _tls _sa _callback =
-    Lwt.fail_with "Tls not available"
+    failwith "Tls not available"
 
   let init ?backlog:_ ~certfile:_ ~keyfile:_ ?stop:_ ?timeout:_ _sa _callback =
-    Lwt.fail_with "Tls not available"
+    failwith "Tls not available"
 end
 
 let available = false

--- a/src/conduit-lwt-unix/conduit_lwt_tls.real.ml
+++ b/src/conduit-lwt-unix/conduit_lwt_tls.real.ml
@@ -53,7 +53,7 @@ module Server = struct
               (fun t ->
                 let ic, oc = Tls_lwt.of_t t in
                 Lwt.return (fd, ic, oc))
-              (fun exn -> Lwt_unix.close fd >>= fun () -> Lwt.fail exn)
+              (fun exn -> Lwt_unix.close fd >>= fun () -> Lwt.reraise exn)
             >>= Conduit_lwt_server.process_accept ?timeout (callback addr))
 
   let init ?backlog ~certfile ~keyfile ?stop ?timeout sa callback =

--- a/src/conduit-lwt-unix/conduit_lwt_unix.ml
+++ b/src/conduit-lwt-unix/conduit_lwt_unix.ml
@@ -175,7 +175,7 @@ let init ?src ?(tls_own_key = `None)
       >>= function
       | { ai_addr; _ } :: _ ->
           Lwt.return { no_source_ctx with src = Some ai_addr }
-      | [] -> Lwt.fail_with "Invalid conduit source address specified")
+      | [] -> failwith "Invalid conduit source address specified")
 
 module Sockaddr_io = struct
   let shutdown_no_exn fd mode =
@@ -267,7 +267,7 @@ let connect_with_tls_native ~ctx (`Hostname hostname, `IP ip, `Port port) =
   (match ctx.tls_own_key with
   | `None -> Lwt.return_none
   | `TLS (_, _, `Password _) ->
-      Lwt.fail_with "OCaml-TLS cannot handle encrypted pem files"
+      failwith "OCaml-TLS cannot handle encrypted pem files"
   | `TLS (`Crt_file_path cert, `Key_file_path priv_key, `No_password) ->
       Conduit_lwt_tls.X509.private_of_pems ~cert ~priv_key
       >|= fun certificate -> Some (`Single certificate))
@@ -311,7 +311,7 @@ let connect_with_default_tls ~ctx tls_client_config =
   match !tls_library with
   | OpenSSL -> connect_with_openssl ~ctx tls_client_config
   | Native -> connect_with_tls_native ~ctx tls_client_config
-  | No_tls -> Lwt.fail_with "No SSL or TLS support compiled into Conduit"
+  | No_tls -> failwith "No SSL or TLS support compiled into Conduit"
 
 (** Main connection function *)
 
@@ -329,9 +329,8 @@ let connect ~ctx (mode : client) =
   | `TLS c -> connect_with_default_tls ~ctx c
   | `OpenSSL c -> connect_with_openssl ~ctx c
   | `TLS_native c -> connect_with_tls_native ~ctx c
-  | `Vchan_direct _ -> Lwt.fail_with "Vchan_direct not available on unix"
-  | `Vchan_domain_socket _uuid ->
-      Lwt.fail_with "Vchan_domain_socket not implemented"
+  | `Vchan_direct _ -> failwith "Vchan_direct not available on unix"
+  | `Vchan_domain_socket _uuid -> failwith "Vchan_domain_socket not implemented"
 
 let sockaddr_on_tcp_port ctx port =
   let open Unix in
@@ -354,7 +353,7 @@ let serve_with_tls_native ?timeout ?stop ~ctx ~certfile ~keyfile ~pass ~port
   let sockaddr, _ = sockaddr_on_tcp_port ctx port in
   (match pass with
   | `No_password -> Lwt.return ()
-  | `Password _ -> Lwt.fail_with "OCaml-TLS cannot handle encrypted pem files")
+  | `Password _ -> failwith "OCaml-TLS cannot handle encrypted pem files")
   >>= fun () ->
   Conduit_lwt_tls.Server.init ~certfile ~keyfile ?timeout ?stop sockaddr
     (fun addr fd ic oc -> callback (flow_of_fd fd addr) ic oc)
@@ -401,9 +400,8 @@ let serve ?backlog ?timeout ?stop ~on_exn ~(ctx : ctx) ~(mode : server) callback
       (`Crt_file_path certfile, `Key_file_path keyfile, pass, `Port port) ->
       serve_with_tls_native ?timeout ?stop ~ctx ~certfile ~keyfile ~pass ~port
         callback
-  | `Vchan_direct _ -> Lwt.fail_with "Vchan_direct not implemented"
-  | `Vchan_domain_socket _uuid ->
-      Lwt.fail_with "Vchan_domain_socket not implemented"
+  | `Vchan_direct _ -> failwith "Vchan_direct not implemented"
+  | `Vchan_domain_socket _uuid -> failwith "Vchan_domain_socket not implemented"
   | `Launchd name ->
       let fn s = Sockaddr_server.init ~on:(`Socket s) ?timeout ?stop callback in
       Conduit_lwt_launchd.activate fn name
@@ -426,23 +424,22 @@ let endp_to_client ~ctx:_ (endp : Conduit.endp) : client Lwt.t =
   | `TLS (host, `TCP (ip, port)) ->
       Lwt.return (`TLS (`Hostname host, `IP ip, `Port port))
   | `TLS (host, endp) ->
-      Lwt.fail_with
-        (Printf.sprintf "TLS to non-TCP currently unsupported: host=%s endp=%s"
-           host
-           (Sexplib.Sexp.to_string_hum (Conduit.sexp_of_endp endp)))
-  | `Unknown err -> Lwt.fail_with ("resolution failed: " ^ err)
+      Printf.ksprintf failwith
+        "TLS to non-TCP currently unsupported: host=%s endp=%s" host
+        (Sexplib.Sexp.to_string_hum (Conduit.sexp_of_endp endp))
+  | `Unknown err -> failwith ("resolution failed: " ^ err)
 
 let endp_to_server ~ctx (endp : Conduit.endp) =
   match endp with
   | `Unix_domain_socket path -> Lwt.return (`Unix_domain_socket (`File path))
   | `TLS (_host, `TCP (_ip, port)) -> (
       match ctx.tls_own_key with
-      | `None -> Lwt.fail_with "No TLS server key configured"
+      | `None -> failwith "No TLS server key configured"
       | `TLS (`Crt_file_path crt, `Key_file_path key, pass) ->
           Lwt.return
             (`TLS (`Crt_file_path crt, `Key_file_path key, pass, `Port port)))
   | `TCP (_ip, port) -> Lwt.return (`TCP (`Port port))
   | `Vchan_direct _ as mode -> Lwt.return mode
   | `Vchan_domain_socket _ as mode -> Lwt.return mode
-  | `TLS (_host, _) -> Lwt.fail_with "TLS to non-TCP currently unsupported"
-  | `Unknown err -> Lwt.fail_with ("resolution failed: " ^ err)
+  | `TLS (_host, _) -> failwith "TLS to non-TCP currently unsupported"
+  | `Unknown err -> failwith ("resolution failed: " ^ err)

--- a/src/conduit-lwt-unix/conduit_lwt_unix_ssl.dummy.ml
+++ b/src/conduit-lwt-unix/conduit_lwt_unix_ssl.dummy.ml
@@ -27,7 +27,7 @@ module Client = struct
 
   let connect ?(ctx = default_ctx) ?src:_ ?hostname:_ ?ip:_ ?verify:_ _sa =
     ignore ctx;
-    Lwt.fail_with "Ssl not available"
+    failwith "Ssl not available"
 end
 
 module Server = struct
@@ -36,7 +36,7 @@ module Server = struct
   let init ?(ctx = default_ctx) ?backlog:_ ?password:_ ~certfile:_ ~keyfile:_
       ?stop:_ ?timeout:_ _sa _cb =
     ignore ctx;
-    Lwt.fail_with "Ssl not available"
+    failwith "Ssl not available"
 end
 
 let available = false

--- a/src/conduit-lwt-unix/conduit_lwt_unix_ssl.real.ml
+++ b/src/conduit-lwt-unix/conduit_lwt_unix_ssl.real.ml
@@ -132,7 +132,7 @@ module Server = struct
             Lwt.try_bind
               (fun () -> Lwt_ssl.ssl_accept fd ctx)
               (fun sock -> Lwt.return (chans_of_fd sock))
-              (fun exn -> Lwt_unix.close fd >>= fun () -> Lwt.fail exn)
+              (fun exn -> Lwt_unix.close fd >>= fun () -> Lwt.reraise exn)
             >>= Conduit_lwt_server.process_accept ?timeout (cb addr))
 end
 

--- a/src/conduit-lwt-unix/resolver_lwt_unix.ml
+++ b/src/conduit-lwt-unix/resolver_lwt_unix.ml
@@ -47,7 +47,7 @@ let system_service name =
       let tls = is_tls_service name in
       let svc = { Resolver.name; port = s.Lwt_unix.s_port; tls } in
       Lwt.return (Some svc))
-    (function Not_found -> Lwt.return_none | e -> Lwt.fail e)
+    (function Not_found -> Lwt.return_none | e -> Lwt.reraise e)
 
 let static_service name =
   match Uri_services.tcp_port_of_service name with

--- a/src/conduit-mirage/conduit_mirage.ml
+++ b/src/conduit-mirage/conduit_mirage.ml
@@ -23,7 +23,7 @@ open Sexplib.Conv
 
 let ( >>= ) = Lwt.( >>= )
 let ( >|= ) = Lwt.( >|= )
-let fail fmt = Fmt.kstr (fun s -> Lwt.fail (Failure s)) fmt
+let fail fmt = Fmt.failwith fmt
 let err_tcp_not_supported = fail "%s: TCP is not supported"
 let err_tls_not_supported = fail "%s: TLS is not supported"
 
@@ -103,8 +103,7 @@ module TCP (S : Tcpip.Stack.V4V6) = struct
   type t = S.t
 
   let err_tcp e =
-    Lwt.fail
-    @@ Failure (Format.asprintf "TCP connection failed: %a" S.TCP.pp_error e)
+    Format.kasprintf failwith "TCP connection failed: %a" S.TCP.pp_error e
 
   let connect (t : t) (c : client) =
     match c with

--- a/src/conduit-mirage/conduit_xenstore.ml
+++ b/src/conduit-mirage/conduit_xenstore.ml
@@ -22,7 +22,7 @@ type direct = [ `Direct of int * Vchan.Port.t ]
 
 let ( >>= ) = Lwt.( >>= )
 let ( / ) = Filename.concat
-let fail fmt = Printf.ksprintf (fun m -> Lwt.fail (Failure m)) fmt
+let fail fmt = Printf.ksprintf failwith fmt
 let err_peer_not_found = fail "Conduit_xenstore: %s peer not found"
 
 let err_no_entry_found () =

--- a/src/conduit-mirage/conduit_xenstore.ml
+++ b/src/conduit-mirage/conduit_xenstore.ml
@@ -48,9 +48,7 @@ module Make (Xs : Xs_client_lwt.S) = struct
   let readdir h d =
     Xs.(directory h d) >>= fun dirs ->
     let dirs = List.filter (fun p -> p <> "") dirs in
-    match dirs with
-    | [] -> Lwt.fail Xs_protocol.Eagain
-    | hd :: _ -> Lwt.return hd
+    match dirs with [] -> raise Xs_protocol.Eagain | hd :: _ -> Lwt.return hd
 
   let register name =
     Xs.make () >>= fun xs ->


### PR DESCRIPTION
Lwt's documentation reads:

> In most cases, it is better to use `failwith s` from the standard
> library.

and

> Whenever possible, it is recommended to use `raise exn` instead, as
> raise captures a backtrace, while `Lwt.fail` does not. If you call
> `raise exn` in a callback that is expected by Lwt to return a
> promise, Lwt will automatically wrap `exn` in a rejected promise,
> but the backtrace will have been recorded by the OCaml runtime.
>
> For example, `bind`'s second argument is a callback which returns a
> promise. And so it is recommended to use `raise` in the body of that
> callback.
>
> Use `Lwt.fail` only when you specifically want to create a rejected
> promise, to pass to another function, or store in a data structure.

Prefer to capture backtraces to improve debugability.

See also [More raise less fail #1008](https://github.com/ocsigen/lwt/pull/1008).